### PR TITLE
fix(ingress): 🐛 inject end frame after stream error and improve admin console UX

### DIFF
--- a/crates/core/src/ir/mod.rs
+++ b/crates/core/src/ir/mod.rs
@@ -526,6 +526,20 @@ impl TruncationReason {
     }
 }
 
+/// An error frame detected inside an otherwise-successful upstream
+/// stream (HTTP 200 with an embedded `{"error": ...}` SSE frame, e.g.
+/// `service_unavailable_error`). The gateway cannot retry these because
+/// the response headers are already committed to the client, but it
+/// must still record the failure for health tracking and telemetry.
+#[derive(Debug, Clone, Default)]
+pub struct UpstreamStreamError {
+    /// Human-readable error message extracted from the error frame.
+    pub message: String,
+    /// Protocol-specific error code/type (e.g. `service_unavailable_error`,
+    /// `overloaded_error`, `429`).
+    pub code: Option<String>,
+}
+
 /// Accumulates usage from streaming responses for billing when the
 /// client disconnects mid-stream. Estimates token counts from
 /// character counts as a fallback.
@@ -544,6 +558,11 @@ pub struct UsageAccumulator {
     /// `completed == true` in the sense that the gateway never sets
     /// both flags — the last call wins.
     pub truncated: Option<TruncationReason>,
+    /// If an error frame was detected inside an otherwise-successful
+    /// upstream stream (HTTP 200 + embedded error SSE frame), this
+    /// holds the error details so downstream observers (capture guard,
+    /// telemetry) can record the failure.
+    pub upstream_error: Option<UpstreamStreamError>,
 }
 
 impl UsageAccumulator {
@@ -574,6 +593,19 @@ impl UsageAccumulator {
     pub fn mark_truncated(&mut self, reason: TruncationReason) {
         self.completed = false;
         self.truncated = Some(reason);
+    }
+
+    /// Record an error frame detected inside the upstream SSE stream
+    /// (HTTP 200 with an embedded `{"error": ...}` frame). The first
+    /// error wins — subsequent calls are ignored so the original
+    /// cause is preserved.
+    pub fn set_upstream_error(&mut self, message: &str, code: Option<&str>) {
+        if self.upstream_error.is_none() {
+            self.upstream_error = Some(UpstreamStreamError {
+                message: message.to_string(),
+                code: code.map(String::from),
+            });
+        }
     }
 
     /// Estimate usage from accumulated characters.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,7 +29,7 @@ pub use header_forward::HeaderForwardPolicy;
 pub use ir::{
     Annotation, AnnotationKind, Content, FinishReason, GenerationParams, IrRequest, IrResponse,
     Message, RawEnvelope, ResponseFormat, Role, StreamPart, ThinkingConfig, ThinkingDisplay,
-    ThinkingEffort, Tool, TruncationReason, Usage, UsageAccumulator,
+    ThinkingEffort, Tool, TruncationReason, UpstreamStreamError, Usage, UsageAccumulator,
 };
 pub use pipeline::{
     ExecutionHook, HookDecision, ObserveHook, PipelineContext, PipelineStage, PreRequestHook,

--- a/crates/core/src/telemetry/mod.rs
+++ b/crates/core/src/telemetry/mod.rs
@@ -363,6 +363,13 @@ pub struct ExchangeCapture {
     /// `None` for non-stream exchanges. Used to compute output
     /// token rate: `completion_tokens / (stream_duration_ms / 1000)`.
     pub stream_duration_ms: Option<u64>,
+    /// When the upstream returned HTTP 200 but the SSE stream
+    /// contained an embedded error frame (e.g.
+    /// `service_unavailable_error`, `overloaded_error`), this
+    /// carries the error message so the OLTP sink can mark the
+    /// request as failed despite the 200 status. `None` for clean
+    /// streams and non-stream exchanges.
+    pub upstream_error: Option<String>,
 }
 
 /// The telemetry bus — decouples event production from consumption.

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -32,6 +32,49 @@ use super::{apply_provider_auth, AppError, AppState};
 /// global `request_read_timeout` (which defaults to 30s for chat).
 const IMAGES_NONSTREAM_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Check whether an HTTP 200 non-streaming response body is actually
+/// an error response (top-level `"error"` key). Some providers return
+/// HTTP 200 with `{"error": {...}}` instead of a proper non-2xx status
+/// code — e.g. `service_unavailable_error`, `overloaded_error`. When
+/// detected, this returns an `AppError` so the fallback loop can
+/// retry / try the next target, instead of silently passing the error
+/// body to the client as a success.
+///
+/// Only triggers when the top-level JSON object has an `"error"` key
+/// and does NOT simultaneously contain normal response fields
+/// (`choices`, `candidates`, `output`, `data`, etc.) that would
+/// indicate a mixed/success response. This avoids false positives on
+/// responses that merely mention "error" in metadata.
+fn check_nonstream_error_body(
+    response_body: &Value,
+    status: u16,
+    retry_after: Option<String>,
+    rate_limit_headers: Vec<(&'static str, String)>,
+) -> Option<AppError> {
+    let error = response_body.get("error")?;
+    // Guard against false positives: if the body also contains
+    // normal response fields, it's not a pure error response.
+    let has_normal_field = ["choices", "candidates", "output", "data", "messages"]
+        .iter()
+        .any(|k| response_body.get(k).is_some());
+    if has_normal_field {
+        return None;
+    }
+    let message = error["message"]
+        .as_str()
+        .unwrap_or("upstream returned error in 200 response body");
+    let mut app_err = AppError::new(
+        StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
+        format!("Upstream error: {}", message),
+    );
+    app_err.upstream_status = Some(status);
+    if let Some(ra) = retry_after {
+        app_err = app_err.with_retry_after_header(ra);
+    }
+    app_err.rate_limit_headers = rate_limit_headers;
+    Some(app_err)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn execute_upstream(
     state: &AppState,
@@ -228,6 +271,7 @@ pub(super) async fn execute_upstream(
                     is_stream: true,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -278,6 +322,8 @@ pub(super) async fn execute_upstream(
             Some(StreamCapture {
                 request_id: request_id.to_string(),
                 telemetry: state.telemetry.clone(),
+                health: Some(state.health.clone()),
+                health_key: Some(target.health_key()),
                 egress_method: egress_method.to_string(),
                 egress_path: egress_path.to_string(),
                 egress_headers: egress_headers_capture,
@@ -375,6 +421,7 @@ pub(super) async fn execute_upstream(
                     is_stream: false,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -391,6 +438,37 @@ pub(super) async fn execute_upstream(
                 app_err = app_err.with_retry_after_header(ra);
             }
             app_err.rate_limit_headers = rate_limit_headers_vec;
+            return Err(app_err);
+        }
+
+        // Detect HTTP 200 responses that are actually error responses
+        // (top-level `"error"` key, e.g. service_unavailable_error).
+        // These must be treated as failures so fallback can retry.
+        if let Some(app_err) = check_nonstream_error_body(
+            &response_body,
+            status.as_u16(),
+            retry_after.clone(),
+            rate_limit_headers_vec.clone(),
+        ) {
+            spawn_capture(
+                state,
+                tiygate_core::ExchangeCapture {
+                    request_id: request_id.to_string(),
+                    egress_method: egress_method.clone(),
+                    egress_path: egress_path.clone(),
+                    egress_headers: egress_headers_capture.clone(),
+                    egress_body: egress_body_capture.clone(),
+                    upstream_status: Some(upstream_status_capture),
+                    upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                    upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                    client_resp_headers: Vec::new(),
+                    client_resp_body: None,
+                    is_stream: false,
+                    truncation_reason: None,
+                    stream_duration_ms: None,
+                    upstream_error: None,
+                },
+            );
             return Err(app_err);
         }
 
@@ -463,6 +541,7 @@ pub(super) async fn execute_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         Ok((response, ttfb_ms))
@@ -628,6 +707,7 @@ pub(super) async fn execute_messages_upstream(
                     is_stream: true,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -674,6 +754,8 @@ pub(super) async fn execute_messages_upstream(
             Some(StreamCapture {
                 request_id: request_id.to_string(),
                 telemetry: state.telemetry.clone(),
+                health: Some(state.health.clone()),
+                health_key: Some(target.health_key()),
                 egress_method: egress_method.to_string(),
                 egress_path: egress_path.to_string(),
                 egress_headers: egress_headers_capture,
@@ -751,6 +833,7 @@ pub(super) async fn execute_messages_upstream(
                     is_stream: false,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -767,6 +850,36 @@ pub(super) async fn execute_messages_upstream(
                 app_err = app_err.with_retry_after_header(ra);
             }
             app_err.rate_limit_headers = rate_limit_headers_vec;
+            return Err(app_err);
+        }
+
+        // Detect HTTP 200 responses that are actually error responses
+        // (top-level `"error"` key, e.g. service_unavailable_error).
+        if let Some(app_err) = check_nonstream_error_body(
+            &response_body,
+            status.as_u16(),
+            retry_after.clone(),
+            rate_limit_headers_vec.clone(),
+        ) {
+            spawn_capture(
+                state,
+                tiygate_core::ExchangeCapture {
+                    request_id: request_id.to_string(),
+                    egress_method: egress_method.clone(),
+                    egress_path: egress_path.clone(),
+                    egress_headers: egress_headers_capture.clone(),
+                    egress_body: egress_body_capture.clone(),
+                    upstream_status: Some(upstream_status_capture),
+                    upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                    upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                    client_resp_headers: Vec::new(),
+                    client_resp_body: None,
+                    is_stream: false,
+                    truncation_reason: None,
+                    stream_duration_ms: None,
+                    upstream_error: None,
+                },
+            );
             return Err(app_err);
         }
 
@@ -831,6 +944,7 @@ pub(super) async fn execute_messages_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         Ok((response, ttfb_ms))
@@ -1045,6 +1159,7 @@ pub(super) async fn execute_embeddings_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         let app_err = AppError::new(
@@ -1055,6 +1170,33 @@ pub(super) async fn execute_embeddings_upstream(
                     .as_str()
                     .unwrap_or("Unknown error")
             ),
+        );
+        return Err(app_err);
+    }
+
+    // Detect HTTP 200 responses that are actually error responses
+    // (top-level `"error"` key, e.g. service_unavailable_error).
+    if let Some(app_err) =
+        check_nonstream_error_body(&response_body, status.as_u16(), None, Vec::new())
+    {
+        spawn_capture(
+            state,
+            tiygate_core::ExchangeCapture {
+                request_id: req_id_capture.to_string(),
+                egress_method: egress_method.clone(),
+                egress_path: egress_path.clone(),
+                egress_headers: egress_headers_capture.clone(),
+                egress_body: egress_body_capture.clone(),
+                upstream_status: Some(upstream_status_capture),
+                upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                client_resp_headers: Vec::new(),
+                client_resp_body: None,
+                is_stream: false,
+                truncation_reason: None,
+                stream_duration_ms: None,
+                upstream_error: None,
+            },
         );
         return Err(app_err);
     }
@@ -1083,6 +1225,7 @@ pub(super) async fn execute_embeddings_upstream(
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         },
     );
 
@@ -1234,6 +1377,7 @@ pub(super) async fn execute_responses_upstream(
                     is_stream: true,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -1268,6 +1412,8 @@ pub(super) async fn execute_responses_upstream(
             Some(StreamCapture {
                 request_id: req_id_capture.clone(),
                 telemetry: state.telemetry.clone(),
+                health: Some(state.health.clone()),
+                health_key: Some(target.health_key()),
                 egress_method: egress_method.to_string(),
                 egress_path: egress_path.to_string(),
                 egress_headers: egress_headers_capture.clone(),
@@ -1361,6 +1507,7 @@ pub(super) async fn execute_responses_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         let mut app_err = AppError::new(
@@ -1374,6 +1521,37 @@ pub(super) async fn execute_responses_upstream(
         app_err.rate_limit_headers = rate_limit_headers_vec;
         return Err(app_err);
     }
+
+    // Detect HTTP 200 responses that are actually error responses
+    // (top-level "error" key, e.g. service_unavailable_error).
+    if let Some(app_err) = check_nonstream_error_body(
+        &response_body,
+        status.as_u16(),
+        retry_after.clone(),
+        rate_limit_headers_vec.clone(),
+    ) {
+        spawn_capture(
+            state,
+            tiygate_core::ExchangeCapture {
+                request_id: req_id_capture.clone(),
+                egress_method: egress_method.clone(),
+                egress_path: egress_path.clone(),
+                egress_headers: egress_headers_capture.clone(),
+                egress_body: egress_body_capture.clone(),
+                upstream_status: Some(upstream_status_capture),
+                upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                client_resp_headers: Vec::new(),
+                client_resp_body: None,
+                is_stream: false,
+                truncation_reason: None,
+                stream_duration_ms: None,
+                upstream_error: None,
+            },
+        );
+        return Err(app_err);
+    }
+
     let upstream_resp_body_capture = serde_json::to_string(&response_body).ok();
     let response_body = if is_same_protocol {
         response_body
@@ -1434,6 +1612,7 @@ pub(super) async fn execute_responses_upstream(
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         },
     );
     Ok((resp, ttfb_ms))
@@ -1603,6 +1782,7 @@ pub(super) async fn execute_gemini_upstream(
                     is_stream: true,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -1637,6 +1817,8 @@ pub(super) async fn execute_gemini_upstream(
             Some(StreamCapture {
                 request_id: req_id_capture.clone(),
                 telemetry: state.telemetry.clone(),
+                health: Some(state.health.clone()),
+                health_key: Some(target.health_key()),
                 egress_method: egress_method.to_string(),
                 egress_path: egress_path.to_string(),
                 egress_headers: egress_headers_capture.clone(),
@@ -1730,6 +1912,7 @@ pub(super) async fn execute_gemini_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         let mut app_err = AppError::new(
@@ -1743,6 +1926,37 @@ pub(super) async fn execute_gemini_upstream(
         app_err.rate_limit_headers = rate_limit_headers_vec;
         return Err(app_err);
     }
+
+    // Detect HTTP 200 responses that are actually error responses
+    // (top-level "error" key, e.g. service_unavailable_error).
+    if let Some(app_err) = check_nonstream_error_body(
+        &response_body,
+        status.as_u16(),
+        retry_after.clone(),
+        rate_limit_headers_vec.clone(),
+    ) {
+        spawn_capture(
+            state,
+            tiygate_core::ExchangeCapture {
+                request_id: req_id_capture.clone(),
+                egress_method: egress_method.clone(),
+                egress_path: egress_path.clone(),
+                egress_headers: egress_headers_capture.clone(),
+                egress_body: egress_body_capture.clone(),
+                upstream_status: Some(upstream_status_capture),
+                upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                client_resp_headers: Vec::new(),
+                client_resp_body: None,
+                is_stream: false,
+                truncation_reason: None,
+                stream_duration_ms: None,
+                upstream_error: None,
+            },
+        );
+        return Err(app_err);
+    }
+
     let upstream_resp_body_capture = serde_json::to_string(&response_body).ok();
     let response_body = if is_same_protocol {
         response_body
@@ -1803,6 +2017,7 @@ pub(super) async fn execute_gemini_upstream(
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         },
     );
     Ok((resp, ttfb_ms))
@@ -1934,6 +2149,7 @@ pub(super) async fn execute_images_generations_upstream(
                     is_stream: true,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -1977,6 +2193,8 @@ pub(super) async fn execute_images_generations_upstream(
             Some(StreamCapture {
                 request_id: request_id.to_string(),
                 telemetry: state.telemetry.clone(),
+                health: Some(state.health.clone()),
+                health_key: Some(target.health_key()),
                 egress_method: egress_method.to_string(),
                 egress_path: egress_path.to_string(),
                 egress_headers: egress_headers_capture,
@@ -2065,6 +2283,7 @@ pub(super) async fn execute_images_generations_upstream(
                     is_stream: false,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2081,6 +2300,36 @@ pub(super) async fn execute_images_generations_upstream(
                 app_err = app_err.with_retry_after_header(ra);
             }
             app_err.rate_limit_headers = rate_limit_headers_vec;
+            return Err(app_err);
+        }
+
+        // Detect HTTP 200 responses that are actually error responses
+        // (top-level `"error"` key, e.g. service_unavailable_error).
+        if let Some(app_err) = check_nonstream_error_body(
+            &response_body,
+            status.as_u16(),
+            retry_after.clone(),
+            rate_limit_headers_vec.clone(),
+        ) {
+            spawn_capture(
+                state,
+                tiygate_core::ExchangeCapture {
+                    request_id: request_id.to_string(),
+                    egress_method: egress_method.clone(),
+                    egress_path: egress_path.clone(),
+                    egress_headers: egress_headers_capture.clone(),
+                    egress_body: egress_body_capture.clone(),
+                    upstream_status: Some(upstream_status_capture),
+                    upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                    upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                    client_resp_headers: Vec::new(),
+                    client_resp_body: None,
+                    is_stream: false,
+                    truncation_reason: None,
+                    stream_duration_ms: None,
+                    upstream_error: None,
+                },
+            );
             return Err(app_err);
         }
 
@@ -2150,6 +2399,7 @@ pub(super) async fn execute_images_generations_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         Ok((response, ttfb_ms))
@@ -2233,6 +2483,7 @@ pub(super) async fn execute_images_edits_upstream(
                     is_stream: true,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2279,6 +2530,8 @@ pub(super) async fn execute_images_edits_upstream(
             Some(StreamCapture {
                 request_id: request_id.to_string(),
                 telemetry: state.telemetry.clone(),
+                health: Some(state.health.clone()),
+                health_key: Some(target.health_key()),
                 egress_method: egress_method.to_string(),
                 egress_path: egress_path.to_string(),
                 egress_headers: egress_headers_capture,
@@ -2359,6 +2612,7 @@ pub(super) async fn execute_images_edits_upstream(
                     is_stream: false,
                     truncation_reason: None,
                     stream_duration_ms: None,
+                    upstream_error: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2375,6 +2629,36 @@ pub(super) async fn execute_images_edits_upstream(
                 app_err = app_err.with_retry_after_header(ra);
             }
             app_err.rate_limit_headers = rate_limit_headers_vec;
+            return Err(app_err);
+        }
+
+        // Detect HTTP 200 responses that are actually error responses
+        // (top-level `"error"` key, e.g. service_unavailable_error).
+        if let Some(app_err) = check_nonstream_error_body(
+            &response_body,
+            status.as_u16(),
+            retry_after.clone(),
+            rate_limit_headers_vec.clone(),
+        ) {
+            spawn_capture(
+                state,
+                tiygate_core::ExchangeCapture {
+                    request_id: request_id.to_string(),
+                    egress_method: egress_method.clone(),
+                    egress_path: egress_path.clone(),
+                    egress_headers: egress_headers_capture.clone(),
+                    egress_body: None,
+                    upstream_status: Some(upstream_status_capture),
+                    upstream_resp_headers: upstream_resp_headers_capture.clone(),
+                    upstream_resp_body: serde_json::to_string(&response_body).ok(),
+                    client_resp_headers: Vec::new(),
+                    client_resp_body: None,
+                    is_stream: false,
+                    truncation_reason: None,
+                    stream_duration_ms: None,
+                    upstream_error: None,
+                },
+            );
             return Err(app_err);
         }
 
@@ -2417,8 +2701,60 @@ pub(super) async fn execute_images_edits_upstream(
                 is_stream: false,
                 truncation_reason: None,
                 stream_duration_ms: None,
+                upstream_error: None,
             },
         );
         Ok((response, ttfb_ms))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_nonstream_error_body_detects_pure_error() {
+        let body = json!({
+            "error": {
+                "type": "service_unavailable_error",
+                "message": "Service unavailable"
+            }
+        });
+        let result = check_nonstream_error_body(&body, 200, None, Vec::new());
+        assert!(result.is_some(), "should detect error body");
+        let err = result.unwrap();
+        assert!(err.message.contains("Service unavailable"));
+        assert_eq!(err.upstream_status, Some(200));
+    }
+
+    #[test]
+    fn check_nonstream_error_body_not_flagged_with_choices() {
+        let body = json!({
+            "choices": [{"message": {"content": "ok"}}],
+            "error": {"type": "minor_warning", "message": "rate limit warning"}
+        });
+        let result = check_nonstream_error_body(&body, 200, None, Vec::new());
+        assert!(result.is_none(), "should not flag when choices present");
+    }
+
+    #[test]
+    fn check_nonstream_error_body_not_flagged_without_error_key() {
+        let body = json!({
+            "choices": [{"message": {"content": "hello"}}]
+        });
+        let result = check_nonstream_error_body(&body, 200, None, Vec::new());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn check_nonstream_error_body_preserves_retry_after() {
+        let body = json!({
+            "error": {"type": "rate_limit", "message": "Too many requests"}
+        });
+        let result = check_nonstream_error_body(&body, 429, Some("30".to_string()), Vec::new());
+        assert!(result.is_some());
+        let err = result.unwrap();
+        assert_eq!(err.retry_after_header, Some("30".to_string()));
     }
 }

--- a/crates/server/src/ingress/streaming.rs
+++ b/crates/server/src/ingress/streaming.rs
@@ -191,6 +191,15 @@ pub(super) struct StreamCapture {
     /// (denylist-filtered upstream headers + content-type), recorded as
     /// the `client_resp_headers` in the detail view.
     pub client_resp_headers: Vec<(String, String)>,
+    /// Health registry for recording stream-level failures (error
+    /// frames, truncation) that arrive after the HTTP 200 `record_success`
+    /// in the fallback loop. When `Some`, the guard calls
+    /// `record_failure` on stream termination if an upstream error or
+    /// truncation was observed.
+    pub health: Option<Arc<tiygate_core::HealthRegistry>>,
+    /// The health-registry key for this routing target
+    /// (`provider_id:model_id`). Paired with `health`.
+    pub health_key: Option<String>,
 }
 
 /// Shared, single-shot finalizer for stream exchange capture.
@@ -202,6 +211,8 @@ pub(super) struct StreamCapture {
 struct StreamCaptureGuard {
     inner: Arc<std::sync::Mutex<StreamCaptureState>>,
     accum: Arc<std::sync::Mutex<UsageAccumulator>>,
+    health: Option<Arc<tiygate_core::HealthRegistry>>,
+    health_key: Option<String>,
 }
 
 struct StreamCaptureState {
@@ -223,6 +234,10 @@ struct StreamCaptureState {
 
 impl StreamCaptureGuard {
     fn new(capture: Option<StreamCapture>, accum: Arc<std::sync::Mutex<UsageAccumulator>>) -> Self {
+        let (health, health_key) = capture
+            .as_ref()
+            .map(|c| (c.health.clone(), c.health_key.clone()))
+            .unwrap_or((None, None));
         Self {
             inner: Arc::new(std::sync::Mutex::new(StreamCaptureState {
                 capture,
@@ -234,6 +249,8 @@ impl StreamCaptureGuard {
                 upstream_completed: false,
             })),
             accum,
+            health,
+            health_key,
         }
     }
 
@@ -276,12 +293,48 @@ impl StreamCaptureGuard {
             .unwrap_or_default()
     }
 
+    /// Check whether the stream terminated with an upstream error or
+    /// gateway-observed truncation, and if so, record a health-registry
+    /// failure for this routing target. This corrects the optimistic
+    /// `record_success` called in the fallback loop (which fires on the
+    /// HTTP 200 before the stream body is consumed) so that consecutive
+    /// stream-level failures still drive the circuit breaker.
+    fn record_health_failure_if_needed(&self) {
+        let should_fail = {
+            let state = self.inner.lock().ok();
+            let truncation_is_failure = state
+                .as_ref()
+                .and_then(|s| s.last_reason)
+                .map(|r| {
+                    matches!(
+                        r,
+                        TruncationReason::UpstreamError
+                            | TruncationReason::Idle
+                            | TruncationReason::Total
+                    )
+                })
+                .unwrap_or(false);
+            let has_upstream_error = self
+                .accum
+                .lock()
+                .map(|a| a.upstream_error.is_some())
+                .unwrap_or(false);
+            truncation_is_failure || has_upstream_error
+        };
+        if should_fail {
+            if let (Some(health), Some(key)) = (&self.health, &self.health_key) {
+                health.record_failure(key);
+            }
+        }
+    }
+
     /// Mark finalized and fire-and-forget the capture via `tokio::spawn`.
     /// Use this **before** the final `yield` / `break` in the stream loop
     /// so that a client disconnect immediately after the last frame does
     /// not cancel an in-flight `finalize().await` and trigger the `Drop`
     /// fallback (`client_disconnect`).
     fn finalize_spawn(&self) {
+        self.record_health_failure_if_needed();
         if let Some((telemetry, capture)) = self.take_capture(None) {
             tokio::spawn(async move {
                 telemetry.send_capture(capture).await;
@@ -317,6 +370,19 @@ impl StreamCaptureGuard {
         } else {
             Some(String::from_utf8_lossy(&state.client_body).into_owned())
         };
+        // Check if the accumulator detected an embedded upstream
+        // error frame (HTTP 200 + SSE error frame like
+        // service_unavailable_error). If so, propagate it to the
+        // capture so the OLTP sink can mark the request as failed.
+        let upstream_error = self.accum.lock().ok().and_then(|a| {
+            a.upstream_error.as_ref().map(|e| {
+                if let Some(code) = &e.code {
+                    format!("{} ({})", e.message, code)
+                } else {
+                    e.message.clone()
+                }
+            })
+        });
         Some((
             telemetry,
             tiygate_core::ExchangeCapture {
@@ -333,6 +399,7 @@ impl StreamCaptureGuard {
                 is_stream: true,
                 truncation_reason: state.last_reason.map(|r| r.as_str().to_string()),
                 stream_duration_ms,
+                upstream_error,
             },
         ))
     }
@@ -355,6 +422,11 @@ impl Drop for StreamCaptureGuard {
         let Some((telemetry, capture)) = self.take_capture(disconnect_reason) else {
             return;
         };
+        // Only reached when finalize_spawn did NOT run (client
+        // disconnect or cancelled future). Record a health failure if
+        // the stream saw an upstream error or a gateway-observed
+        // truncation before the disconnect.
+        self.record_health_failure_if_needed();
         if let Some(reason) = disconnect_reason {
             if let Ok(mut a) = self.accum.lock() {
                 a.mark_truncated(reason);
@@ -397,6 +469,67 @@ pub(super) struct StreamTranscode {
     pub encoder: Box<dyn tiygate_core::StreamEncoder>,
 }
 
+/// Lightweight scan of verbatim upstream SSE bytes for error frames.
+///
+/// In the verbatim (same-protocol) streaming path the gateway forwards
+/// upstream bytes without parsing them. This function performs a cheap
+/// detection pass to find `data:` lines whose JSON payload contains a
+/// top-level `"error"` key — the shape used by OpenAI, Anthropic, and
+/// Google when embedding an error frame inside an HTTP 200 SSE stream
+/// (e.g. `service_unavailable_error`, `overloaded_error`).
+///
+/// When an error frame is found, the details are recorded in the
+/// `UsageAccumulator` so downstream observers (capture guard, telemetry)
+/// can mark the request as failed despite the HTTP 200 status.
+///
+/// The scan is deliberately conservative: it only parses `data:` lines
+/// that contain the byte substring `"error"`, and only treats a payload
+/// as an error when the parsed JSON has a top-level `"error"` object.
+/// Normal response chunks that merely mention "error" in content text
+/// are not affected because their JSON will not have a top-level
+/// `"error"` key.
+fn detect_verbatim_error(bytes: &[u8], accum: &Arc<std::sync::Mutex<UsageAccumulator>>) {
+    // Quick gate: skip the parse entirely if `"error"` is not present.
+    if !bytes.windows(7).any(|w| w == b"\"error\"") {
+        return;
+    }
+    // Best-effort UTF-8 conversion for scanning SSE line prefixes.
+    let text = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => &String::from_utf8_lossy(bytes),
+    };
+    for line in text.lines() {
+        let trimmed = line.trim();
+        // SSE data lines look like `data: { ... }` or `data:{ ... }`.
+        let json_str = if let Some(rest) = trimmed.strip_prefix("data:") {
+            rest.trim()
+        } else if trimmed.starts_with("event:") {
+            // Anthropic uses `event: error\ndata: {...}` — the error
+            // payload is on the following `data:` line, which will be
+            // picked up in the next iteration. Skip the event marker.
+            continue;
+        } else {
+            continue;
+        };
+        if json_str.is_empty() || json_str == "[DONE]" {
+            continue;
+        }
+        // Only attempt JSON parse if this line contains `"error"`.
+        if !json_str.contains("\"error\"") {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) {
+            if let Some(error) = value.get("error") {
+                let message = error["message"].as_str().unwrap_or("upstream stream error");
+                let code = error["type"].as_str().or_else(|| error["code"].as_str());
+                if let Ok(mut a) = accum.lock() {
+                    a.set_upstream_error(message, code);
+                }
+            }
+        }
+    }
+}
+
 /// Split a UTF-8 SSE buffer into complete lines, returning the parsed lines
 /// and any trailing partial line (no terminating `\n` yet) that must be
 /// carried over to the next chunk. SSE events are delimited by blank lines
@@ -424,12 +557,12 @@ pub(super) fn drive_upstream_stream(
     _state: &AppState,
     accum: Arc<std::sync::Mutex<UsageAccumulator>>,
     response: reqwest::Response,
-    // Retained for API/call-site compatibility, but the gateway no longer
-    // synthesizes a success terminator: a clean upstream EOF ends the
-    // client stream at EOF (no fabricated `[DONE]`), and gateway-observed
-    // failures emit `error_marker` instead. See the `None`/idle/error
-    // branches below for the rationale.
-    _end_marker: Vec<u8>,
+    // Protocol-native end frame (e.g. `data: [DONE]\n\n`). Emitted on a
+    // clean upstream EOF **only** when the upstream delivered an error
+    // frame but no terminal signal — this lets the client SDK close the
+    // stream cleanly instead of timing out. Gateway-observed failures
+    // (idle / total / mid-stream error) emit `error_marker` instead.
+    end_marker: Vec<u8>,
     error_marker: Vec<u8>,
     idle_timeout: Duration,
     total_timeout: Duration,
@@ -569,6 +702,19 @@ pub(super) fn drive_upstream_stream(
                                                 ) {
                                                     saw_terminal = true;
                                                 }
+                                                // Detect upstream error frames
+                                                // embedded in an HTTP 200 SSE
+                                                // stream (e.g.
+                                                // service_unavailable_error).
+                                                // Record in the accumulator so
+                                                // the capture guard /
+                                                // telemetry can mark the
+                                                // request as failed.
+                                                if let tiygate_core::ir::StreamPart::Error { message, code } = part {
+                                                    if let Ok(mut a) = accum.lock() {
+                                                        a.set_upstream_error(message, code.as_deref());
+                                                    }
+                                                }
                                                 match tc.encoder.encode_part(part) {
                                                     Ok(b) => out.extend_from_slice(&b),
                                                     Err(e) => {
@@ -605,6 +751,19 @@ pub(super) fn drive_upstream_stream(
                                 // (`data: ...\n\n`); wrapping it in an axum
                                 // `Event` would double-prefix `data:` and
                                 // corrupt the stream. Pass the raw bytes.
+                                //
+                                // Lightweight error-frame scan: when the
+                                // chunk contains a `data:` SSE line whose
+                                // JSON payload has a top-level `"error"`
+                                // key (e.g.
+                                // `data: {"error":{"type":"service_unavailable_error",...}}`),
+                                // record it in the accumulator so the
+                                // capture guard / telemetry can mark the
+                                // request as failed despite the HTTP 200
+                                // status. The scan is cheap: a byte
+                                // substring search for `"error"` gates the
+                                // more expensive JSON parse.
+                                detect_verbatim_error(&bytes, &accum);
                                 capture_guard.append_client(&bytes);
                                 yield Ok(bytes);
                             }
@@ -754,6 +913,25 @@ pub(super) fn drive_upstream_stream(
                                         }
                                     }
                                 }
+                                // When the upstream sent an error frame
+                                // but no terminal signal, the client SDK
+                                // would hang waiting for its protocol-
+                                // native end frame. Emit `encode_done()`
+                                // (a pure terminator with no success
+                                // semantics, e.g. `data: [DONE]`) so the
+                                // SDK closes the stream cleanly.
+                                if !saw_terminal {
+                                    let has_upstream_error = accum
+                                        .lock()
+                                        .map(|a| a.upstream_error.is_some())
+                                        .unwrap_or(false);
+                                    if has_upstream_error {
+                                        let done = tc.encoder.encode_done();
+                                        if !done.is_empty() {
+                                            out.extend_from_slice(&done);
+                                        }
+                                    }
+                                }
                                 if !out.is_empty() {
                                     capture_guard.append_client(&out);
                                     yield Ok(Bytes::from(out));
@@ -773,6 +951,21 @@ pub(super) fn drive_upstream_stream(
                                 // and the appended terminator would glue onto a
                                 // half-written `data:` line. End at EOF and let
                                 // the client decide.
+                                //
+                                // Exception: when the upstream delivered an
+                                // error frame (detected via
+                                // `detect_verbatim_error`) but no natural
+                                // terminator, emit the protocol-native end
+                                // marker so the client SDK does not time out
+                                // waiting for it.
+                                let has_upstream_error = accum
+                                    .lock()
+                                    .map(|a| a.upstream_error.is_some())
+                                    .unwrap_or(false);
+                                if has_upstream_error && !end_marker.is_empty() {
+                                    capture_guard.append_client(&end_marker);
+                                    yield Ok(Bytes::from(end_marker.clone()));
+                                }
                             }
                             // Finalize capture BEFORE break: the client may
                             // close immediately after receiving the last frame
@@ -945,6 +1138,8 @@ mod tests {
             upstream_status: Some(200),
             upstream_resp_headers: Vec::new(),
             client_resp_headers: Vec::new(),
+            health: None,
+            health_key: None,
         }
     }
 
@@ -1064,5 +1259,200 @@ mod tests {
         // Accumulator should NOT be marked truncated.
         let acc = accum.lock().unwrap();
         assert!(acc.truncated.is_none());
+    }
+
+    // --- detect_verbatim_error tests ---
+
+    #[test]
+    fn detect_verbatim_error_openai_style() {
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        let bytes = b"data: {\"error\":{\"type\":\"service_unavailable_error\",\"message\":\"Service unavailable\"}}\n\n";
+        detect_verbatim_error(bytes, &accum);
+        let acc = accum.lock().unwrap();
+        let err = acc.upstream_error.as_ref().expect("error should be set");
+        assert_eq!(err.message, "Service unavailable");
+        assert_eq!(err.code.as_deref(), Some("service_unavailable_error"));
+    }
+
+    #[test]
+    fn detect_verbatim_error_anthropic_style() {
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        // Anthropic uses event: error + data: {...}
+        let bytes = b"event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n";
+        detect_verbatim_error(bytes, &accum);
+        let acc = accum.lock().unwrap();
+        let err = acc.upstream_error.as_ref().expect("error should be set");
+        assert_eq!(err.message, "Overloaded");
+        assert_eq!(err.code.as_deref(), Some("overloaded_error"));
+    }
+
+    #[test]
+    fn detect_verbatim_error_normal_chunk_not_flagged() {
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        // A normal chunk that contains "error" in content text but not
+        // as a top-level key.
+        let bytes = b"data: {\"choices\":[{\"delta\":{\"content\":\"An error occurred\"}}]}\n\n";
+        detect_verbatim_error(bytes, &accum);
+        let acc = accum.lock().unwrap();
+        assert!(acc.upstream_error.is_none(), "should not flag normal chunk");
+    }
+
+    #[test]
+    fn detect_verbatim_error_no_error_key_skipped() {
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        let bytes = b"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n";
+        detect_verbatim_error(bytes, &accum);
+        let acc = accum.lock().unwrap();
+        assert!(acc.upstream_error.is_none());
+    }
+
+    #[test]
+    fn detect_verbatim_error_first_error_wins() {
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        let bytes1 = b"data: {\"error\":{\"type\":\"service_unavailable_error\",\"message\":\"First error\"}}\n\n";
+        let bytes2 =
+            b"data: {\"error\":{\"type\":\"overloaded_error\",\"message\":\"Second error\"}}\n\n";
+        detect_verbatim_error(bytes1, &accum);
+        detect_verbatim_error(bytes2, &accum);
+        let acc = accum.lock().unwrap();
+        let err = acc.upstream_error.as_ref().expect("error should be set");
+        assert_eq!(err.message, "First error");
+    }
+
+    #[tokio::test]
+    async fn stream_capture_guard_propagates_upstream_error_to_capture() {
+        let bus = Arc::new(CapturingBus::default());
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        {
+            // Simulate detecting an error frame during streaming
+            {
+                let mut a = accum.lock().unwrap();
+                a.set_upstream_error("Service unavailable", Some("service_unavailable_error"));
+            }
+            let guard =
+                StreamCaptureGuard::new(Some(sample_stream_capture(bus.clone())), accum.clone());
+            guard.append_upstream(b"data: {\"error\":{...}}\n\n");
+            guard.append_client(b"data: {\"error\":{...}}\n\n");
+            guard.mark_upstream_completed();
+            guard.finalize_spawn();
+        }
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if bus.captures.lock().unwrap().len() == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("finalize_spawn should complete");
+
+        let captures = bus.captures.lock().unwrap();
+        assert_eq!(captures.len(), 1);
+        let capture = &captures[0];
+        assert!(
+            capture.upstream_error.is_some(),
+            "upstream_error should be propagated"
+        );
+        assert!(capture
+            .upstream_error
+            .as_ref()
+            .unwrap()
+            .contains("Service unavailable"));
+        assert!(capture
+            .upstream_error
+            .as_ref()
+            .unwrap()
+            .contains("service_unavailable_error"));
+    }
+
+    #[tokio::test]
+    async fn record_health_failure_on_upstream_error() {
+        let health = Arc::new(tiygate_core::HealthRegistry::new(
+            1,
+            vec![Duration::from_secs(60)],
+        ));
+        let key = "provider:model".to_string();
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        {
+            let mut a = accum.lock().unwrap();
+            a.set_upstream_error("Service unavailable", Some("service_unavailable_error"));
+        }
+        let bus = Arc::new(CapturingBus::default());
+        let mut capture = sample_stream_capture(bus);
+        capture.health = Some(health.clone());
+        capture.health_key = Some(key.clone());
+        let guard = StreamCaptureGuard::new(Some(capture), accum.clone());
+        guard.finalize_spawn();
+        // After an upstream error, the target should be unhealthy
+        // (threshold = 1).
+        assert!(
+            !health.is_healthy(&key),
+            "health should record failure after upstream error"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_health_failure_on_clean_stream() {
+        let health = Arc::new(tiygate_core::HealthRegistry::new(
+            1,
+            vec![Duration::from_secs(60)],
+        ));
+        let key = "provider:model".to_string();
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        let bus = Arc::new(CapturingBus::default());
+        let mut capture = sample_stream_capture(bus);
+        capture.health = Some(health.clone());
+        capture.health_key = Some(key.clone());
+        let guard = StreamCaptureGuard::new(Some(capture), accum.clone());
+        guard.mark_upstream_completed();
+        guard.finalize_spawn();
+        assert!(
+            health.is_healthy(&key),
+            "health should remain healthy on clean stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_health_failure_on_truncation() {
+        let health = Arc::new(tiygate_core::HealthRegistry::new(
+            1,
+            vec![Duration::from_secs(60)],
+        ));
+        let key = "provider:model".to_string();
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        let bus = Arc::new(CapturingBus::default());
+        let mut capture = sample_stream_capture(bus);
+        capture.health = Some(health.clone());
+        capture.health_key = Some(key.clone());
+        let guard = StreamCaptureGuard::new(Some(capture), accum.clone());
+        guard.set_reason(Some(TruncationReason::Idle));
+        guard.finalize_spawn();
+        assert!(
+            !health.is_healthy(&key),
+            "health should record failure after idle truncation"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_health_failure_on_client_disconnect_only() {
+        let health = Arc::new(tiygate_core::HealthRegistry::new(
+            1,
+            vec![Duration::from_secs(60)],
+        ));
+        let key = "provider:model".to_string();
+        let accum = Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
+        let bus = Arc::new(CapturingBus::default());
+        let mut capture = sample_stream_capture(bus);
+        capture.health = Some(health.clone());
+        capture.health_key = Some(key.clone());
+        // Simulate client disconnect without upstream error or gateway
+        // truncation — Drop path sets ClientDisconnect, which is NOT
+        // a failure reason for health.
+        drop(StreamCaptureGuard::new(Some(capture), accum));
+        assert!(
+            health.is_healthy(&key),
+            "client disconnect alone should not trigger health failure"
+        );
     }
 }

--- a/crates/server/src/telemetry.rs
+++ b/crates/server/src/telemetry.rs
@@ -321,6 +321,7 @@ mod tests {
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         }
     }
 }

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -621,6 +621,61 @@ async fn test_streaming_chat_completion_forwards_done_frame() {
 }
 
 #[tokio::test]
+async fn test_streaming_error_frame_injects_end_marker() {
+    // When the upstream returns HTTP 200 with an SSE error frame (e.g.
+    // service_unavailable_error) and then closes the stream WITHOUT a
+    // natural terminal frame (`data: [DONE]`), the gateway must inject
+    // the protocol-native end marker so the client SDK does not time
+    // out waiting for it.
+    let mock_server = wiremock::MockServer::start().await;
+
+    let sse_error = "data: {\"error\":{\"type\":\"service_unavailable_error\",\"message\":\"Service unavailable\"}}\n\n";
+
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/chat/completions"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_error),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let app = build_openai_test_app(mock_server.uri(), "gpt-4o");
+
+    let body = json!({
+        "model": "gpt-4o",
+        "stream": true,
+        "messages": [{"role": "user", "content": "Hi"}]
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body_bytes);
+    // The upstream error frame must be forwarded.
+    assert!(
+        body_str.contains("service_unavailable_error"),
+        "expected upstream error frame, got: {body_str}"
+    );
+    // The gateway must inject `data: [DONE]` so the client SDK can
+    // close the stream cleanly.
+    assert!(
+        body_str.contains("data: [DONE]"),
+        "expected gateway-injected end marker, got: {body_str}"
+    );
+}
+
+#[tokio::test]
 async fn test_passthrough_forwards_raw_body_verbatim() {
     // PassThrough contract: when the target's protocol suite matches the
     // ingress suite and the codec declares Passthrough, the gateway

--- a/crates/store/src/log_sink/oltp.rs
+++ b/crates/store/src/log_sink/oltp.rs
@@ -358,6 +358,30 @@ impl EventSink for OltpSink {
             }
         }
 
+        // When the upstream returned HTTP 200 but the SSE stream
+        // contained an embedded error frame (e.g.
+        // service_unavailable_error), mark the request as failed.
+        // This is the streaming equivalent of a non-2xx error body:
+        // the gateway already forwarded the error frame to the
+        // client, but the hot-path `emit_ok` recorded the request
+        // as success because the HTTP status was 200. This
+        // write-back corrects the status so the dashboard surfaces
+        // the failure. Uses the same upsert strategy as
+        // `update_request_truncation` so it is order-independent
+        // with `write_request_event`.
+        if let Some(error_source) = &capture.upstream_error {
+            if let Err(e) = self
+                .update_request_failure(&capture.request_id, "transient", error_source)
+                .await
+            {
+                warn!(
+                    error = %e,
+                    request_id = %capture.request_id,
+                    "oltp sink: upstream_error failure write-back failed"
+                );
+            }
+        }
+
         // Only after the payload row and the best-effort SSE parsed
         // fields have been written do we expose the row to the archive
         // worker. Terminal archive states are preserved so a late or
@@ -579,6 +603,14 @@ impl OltpSink {
     /// error frame. Uses the same upsert placeholder strategy as
     /// [`update_request_truncation`] so it is order-independent with
     /// `write_request_event`.
+    ///
+    /// Also sets `truncation_reason` to the provided value so the
+    /// `write_request_event` `ON CONFLICT` clause (which preserves
+    /// `status`/`error_class`/`error_source` when
+    /// `truncation_reason` is in the failure set) does not clobber
+    /// the failure with the hot-path `Success` status. This is used
+    /// both for genuine truncation failures and for upstream error
+    /// frames embedded in an HTTP 200 SSE stream.
     async fn update_request_failure(
         &self,
         request_id: &str,
@@ -590,12 +622,13 @@ impl OltpSink {
             "INSERT INTO request_logs (\
                 request_id, ts, virtual_model, ingress_protocol, status, \
                 total_latency_ms, upstream_latency_ms, queue_latency_ms, lossy, \
-                error_class, error_source) \
-             VALUES ($1, $2, '', '', 'failed', 0, 0, 0, 0, $3, $4) \
+                error_class, error_source, truncation_reason) \
+             VALUES ($1, $2, '', '', 'failed', 0, 0, 0, 0, $3, $4, 'upstream_error') \
              ON CONFLICT(request_id) DO UPDATE SET \
                 status = excluded.status, \
                 error_class = excluded.error_class, \
-                error_source = excluded.error_source",
+                error_source = excluded.error_source, \
+                truncation_reason = COALESCE(request_logs.truncation_reason, excluded.truncation_reason)",
         )
         .bind(request_id)
         .bind(now)
@@ -3158,6 +3191,7 @@ mod tests {
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -3216,6 +3250,7 @@ mod tests {
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -3723,7 +3758,9 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             client_resp_body: None,
             is_stream: false,
             truncation_reason: None,
-            stream_duration_ms: None,        };
+            stream_duration_ms: None,
+            upstream_error: None,
+        };
         sink.write_capture(&capture).await.expect("write capture");
 
         let row =
@@ -3777,6 +3814,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -3826,6 +3864,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             is_stream: true,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -3868,6 +3907,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             is_stream: false,
             truncation_reason: None,
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
         let count: i64 =
@@ -3919,6 +3959,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             is_stream: true,
             truncation_reason: Some("idle".to_string()),
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -3964,6 +4005,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             is_stream: true,
             truncation_reason: Some("upstream_error".to_string()),
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4017,6 +4059,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             is_stream: true,
             truncation_reason: Some("client_disconnect".to_string()),
             stream_duration_ms: None,
+            upstream_error: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4037,5 +4080,67 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             row.get::<Option<String>, _>("truncation_reason"),
             Some("client_disconnect".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn write_capture_upstream_error_marks_request_failed() {
+        let pool = db::open_pool("sqlite::memory:").await.expect("pool");
+        db::run_migrations(&pool).await.expect("migrate");
+        let sink = OltpSink::new(Arc::new(pool.clone()));
+
+        // Hot path emits a success RequestEvent (the normal flow for a
+        // streaming response whose upstream error is discovered later).
+        sink.write_request_event(&dummy_request_event())
+            .await
+            .expect("write event");
+
+        let capture = ExchangeCapture {
+            request_id: "req-1".to_string(),
+            egress_method: "POST".to_string(),
+            egress_path: "/v1/chat/completions".to_string(),
+            egress_headers: vec![],
+            egress_body: None,
+            upstream_status: Some(200),
+            upstream_resp_headers: vec![],
+            upstream_resp_body: Some(
+                "data: {\"error\":{\"type\":\"service_unavailable_error\",\"message\":\"Service unavailable\"}}\n\n".to_string(),
+            ),
+            client_resp_headers: vec![],
+            client_resp_body: None,
+            is_stream: true,
+            truncation_reason: None,
+            stream_duration_ms: None,
+            upstream_error: Some(
+                "Service unavailable (service_unavailable_error)".to_string(),
+            ),
+        };
+        sink.write_capture(&capture).await.expect("write capture");
+
+        // The success RequestEvent arrives later (hot path). Its
+        // status must NOT override the failure already written by the
+        // capture's upstream_error write-back, because
+        // update_request_failure sets truncation_reason =
+        // 'upstream_error'.
+        let mut ev = dummy_request_event();
+        ev.request_id = "req-1".to_string();
+        sink.write_request_event(&ev).await.expect("write event");
+
+        let row = sqlx::query(
+            "SELECT status, error_class, error_source \
+             FROM request_logs WHERE request_id = $1",
+        )
+        .bind("req-1")
+        .fetch_one(pool.any())
+        .await
+        .expect("query");
+        assert_eq!(row.get::<String, _>("status"), "failed");
+        assert_eq!(
+            row.get::<Option<String>, _>("error_class"),
+            Some("transient".to_string())
+        );
+        assert!(row
+            .get::<Option<String>, _>("error_source")
+            .unwrap()
+            .contains("Service unavailable"));
     }
 }

--- a/webui/index.html
+++ b/webui/index.html
@@ -47,7 +47,71 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- Pre-React boot screen: shown until main.tsx mounts.
+           Inline CSS keeps it dependency-free and theme-aware. -->
+      <div id="boot-splash" style="display:flex;min-height:100vh;align-items:center;justify-content:center;">
+        <div style="display:flex;flex-direction:column;align-items:center;gap:24px;width:100%;max-width:320px;padding:0 16px;">
+          <span style="display:flex;height:48px;width:48px;align-items:center;justify-content:center;border-radius:8px;overflow:hidden;">
+            <img src="./icon.svg" alt="" aria-hidden="true" style="height:48px;width:48px;" />
+          </span>
+          <div style="width:100%;">
+            <div style="height:4px;width:100%;border-radius:9999px;background-color:rgba(128,128,128,0.2);overflow:hidden;">
+              <div id="boot-progress" style="height:100%;width:8%;border-radius:9999px;background-color:#6366f1;transition:width 0.3s ease-out;"></div>
+            </div>
+          </div>
+          <p id="boot-hint" style="font-size:14px;color:rgba(128,128,128,0.8);">Loading resources, please wait…</p>
+        </div>
+      </div>
+    </div>
+    <script>
+      // Animate the inline progress bar and localize the hint text.
+      (() => {
+        const root = document.documentElement;
+        const isDark = root.getAttribute("data-theme") === "dark";
+        const bar = document.getElementById("boot-progress");
+        const hint = document.getElementById("boot-hint");
+        // Localize the hint text — prefer stored i18n preference.
+        let i18nLang = "";
+        try { i18nLang = (window.localStorage.getItem("i18nextLng") || "").toLowerCase(); } catch {}
+        const lang = (i18nLang || navigator.language || "en").toLowerCase();
+
+        // Localize the hint text.
+        if (lang.startsWith("zh")) {
+          hint.textContent = "正在加载资源，请稍候…";
+        } else {
+          hint.textContent = "Loading resources, please wait…";
+        }
+
+        // Theme-aware bar color — try the CSS variable first, fall back
+        // to hardcoded values for the default theme.
+        let primaryColor = isDark ? "#84a6ff" : "#2e5be6";
+        try {
+          const cs = getComputedStyle(root);
+          const cssPrimary = cs.getPropertyValue("--primary").trim();
+          if (cssPrimary) primaryColor = cssPrimary;
+        } catch {}
+        bar.style.backgroundColor = primaryColor;
+
+        // Simulate progress toward 90% — the React app will replace
+        // this element when it mounts.
+        let progress = 8;
+        const timer = setInterval(() => {
+          if (progress >= 88) return;
+          const remaining = 90 - progress;
+          progress = Math.min(90, progress + Math.max(1, remaining * 0.12));
+          bar.style.width = progress + "%";
+        }, 200);
+
+        // Clean up when React takes over.
+        new MutationObserver((_, observer) => {
+          if (!document.getElementById("boot-splash")) {
+            clearInterval(timer);
+            observer.disconnect();
+          }
+        }).observe(document.getElementById("root"), { childList: true, subtree: true });
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/webui/src/auth/Login.tsx
+++ b/webui/src/auth/Login.tsx
@@ -10,11 +10,11 @@ import {
   ErrorBox,
   Field,
   PasswordInput,
-  Spinner,
   Switch,
 } from "@/components/ui";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { InstanceIndicator } from "@/components/InstanceIndicator";
+import { BootScreen } from "@/components/BootScreen";
 import { cn } from "@/lib/cn";
 
 export default function Login() {
@@ -75,11 +75,7 @@ export default function Login() {
   }
 
   if (isTauri && !tauriCheckDone) {
-    return (
-      <div className="flex min-h-full items-center justify-center bg-bg">
-        <Spinner />
-      </div>
-    );
+    return <BootScreen />;
   }
 
   return (

--- a/webui/src/auth/ProtectedRoute.tsx
+++ b/webui/src/auth/ProtectedRoute.tsx
@@ -3,7 +3,7 @@ import { Navigate } from "react-router-dom";
 import { useAuth } from "@/auth/AuthContext";
 import { shouldShowLocalSetup } from "@/auth/setup";
 import { useEffect, useState } from "react";
-import { Spinner } from "@/components/ui";
+import { BootScreen } from "@/components/BootScreen";
 
 export default function ProtectedRoute({ children }: PropsWithChildren) {
   const { isAuthenticated, isTauri, isInitializing } = useAuth();
@@ -34,11 +34,7 @@ export default function ProtectedRoute({ children }: PropsWithChildren) {
     isTauri &&
     (isInitializing || (!isAuthenticated && needsLocalSetup === null))
   ) {
-    return (
-      <div className="flex min-h-full items-center justify-center bg-bg">
-        <Spinner />
-      </div>
-    );
+    return <BootScreen />;
   }
 
   // In Tauri mode, only force setup for the local sidecar.

--- a/webui/src/components/BootScreen.tsx
+++ b/webui/src/components/BootScreen.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Full-screen boot/loading screen shown during application startup.
+ * Displays the brand logo, an animated progress bar, and a loading hint.
+ */
+export function BootScreen() {
+  const { t } = useTranslation();
+  const [progress, setProgress] = useState(8);
+
+  useEffect(() => {
+    // Simulate smooth progress towards 95% — never reaches 100%
+    // until the actual loading completes and this component unmounts.
+    const timer = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 92) return prev;
+        // Decelerating approach: larger jumps early, smaller near the end
+        const remaining = 95 - prev;
+        return Math.min(95, prev + Math.max(1, remaining * 0.15));
+      });
+    }, 200);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="flex min-h-full items-center justify-center bg-bg px-4 py-10">
+      <div className="flex w-full max-w-[320px] flex-col items-center gap-6">
+        {/* Brand logo */}
+        <span className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-lg">
+          <img
+            src="./icon.svg"
+            alt=""
+            aria-hidden
+            className="h-12 w-12"
+          />
+        </span>
+
+        {/* Progress bar */}
+        <div className="w-full">
+          <div className="h-1 w-full overflow-hidden rounded-full bg-surface-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Loading hint */}
+        <p className="text-sm text-text-muted">
+          {t("common.bootLoading")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/components/TokenHeatmap.tsx
+++ b/webui/src/components/TokenHeatmap.tsx
@@ -185,8 +185,18 @@ export function TokenHeatmap({ data, spanDays = 365, isLoading }: TokenHeatmapPr
   ];
 
   if (isLoading) {
+    // Match the real heatmap's intrinsic width: 53 week-columns × 14px
+    // (11px cell + 3px gap) − 3px trailing gap ≈ 739px.
     return (
-      <div className="h-[160px] animate-pulse rounded-lg bg-surface-secondary" />
+      <div className="space-y-3" style={{ minWidth: 739 }}>
+        {/* Header placeholder */}
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-24 animate-pulse rounded bg-surface-secondary" />
+          <div className="h-6 w-24 animate-pulse rounded-md bg-surface-secondary" />
+        </div>
+        {/* Grid placeholder */}
+        <div className="h-[113px] animate-pulse rounded-lg bg-surface-secondary" />
+      </div>
     );
   }
 

--- a/webui/src/i18n/locales/en.ts
+++ b/webui/src/i18n/locales/en.ts
@@ -86,6 +86,7 @@ const en = {
   },
   common: {
     loading: "Loading…",
+    bootLoading: "Loading resources, please wait…",
     error: "Error: {{message}}",
     empty: "No data.",
     emptyTitle: "Nothing here yet",

--- a/webui/src/i18n/locales/zh.ts
+++ b/webui/src/i18n/locales/zh.ts
@@ -85,6 +85,7 @@ const zh: Translation = {
   },
   common: {
     loading: "加载中…",
+    bootLoading: "正在加载资源，请稍候…",
     error: "错误：{{message}}",
     empty: "暂无数据。",
     emptyTitle: "这里还没有内容",

--- a/webui/src/pages/RequestLogs.tsx
+++ b/webui/src/pages/RequestLogs.tsx
@@ -633,7 +633,9 @@ export default function RequestLogs() {
                       )}
                     </Td>
                     <Td className="text-right tabular-nums">
-                      {r.ttfb_ms ?? "—"}
+                      {r.ttfb_ms != null
+                        ? `${Math.max(0.01, r.ttfb_ms / 1000).toFixed(2)}s`
+                        : "—"}
                     </Td>
                     <Td className="text-right tabular-nums">
                       {r.stream_duration_ms &&

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   PasswordInput,
   Select,
+  Skeleton,
   Switch,
   useToast,
 } from "@/components/ui";
@@ -181,8 +182,45 @@ export default function SettingsPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <span className="text-muted-foreground">{t("common.loading")}</span>
+      <div className="space-y-6">
+        {/* PageHeader skeleton */}
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-48" />
+            <Skeleton className="h-4 w-72" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-20" />
+          </div>
+        </div>
+
+        {/* Card skeleton: 2-column grid of field placeholders */}
+        {[
+          { rows: 5, cols: true },
+          { rows: 12, cols: true },
+          { rows: 7, cols: true },
+          { rows: 5, cols: true },
+          { rows: 2, cols: false },
+        ].map((section, i) => (
+          <Card key={i}>
+            <div className="border-b border-border px-4 py-3">
+              <Skeleton className="h-4 w-40" />
+            </div>
+            <CardBody
+              className={
+                section.cols ? "grid gap-4 sm:grid-cols-2" : "grid gap-4"
+              }
+            >
+              {Array.from({ length: section.rows }).map((_, j) => (
+                <div key={j} className="space-y-2">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-9 w-full" />
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        ))}
       </div>
     );
   }

--- a/webui/src/pages/Setup.tsx
+++ b/webui/src/pages/Setup.tsx
@@ -33,6 +33,7 @@ import {
   Switch,
 } from "@/components/ui";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { BootScreen } from "@/components/BootScreen";
 import { cn } from "@/lib/cn";
 
 type Mode =
@@ -339,14 +340,7 @@ export default function Setup() {
   }
 
   if (mode === "busy") {
-    return (
-      <div className="flex min-h-full items-center justify-center bg-bg px-4 py-10">
-        <div className="flex flex-col items-center gap-3">
-          <Spinner />
-          <p className="text-sm text-text-muted">{t("setup.starting")}</p>
-        </div>
-      </div>
-    );
+    return <BootScreen />;
   }
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes a streaming reliability gap and improves the admin console UX:

- **Streaming error frame handling**: When an upstream returns HTTP 200 with an embedded SSE error frame (e.g. `service_unavailable_error`) and closes without a terminal signal, the gateway now injects the protocol-native end marker (`data: [DONE]` / `message_stop`) so client SDKs close cleanly instead of timing out. Stream-level failures are also written back to the health registry to drive circuit-breaker behavior.
- **WebUI boot screen & skeleton loading**: Replaces bare Spinner placeholders with a polished BootScreen component and inline HTML boot splash for instant visual feedback before React mounts. Adds skeleton loading states for TokenHeatmap and Settings page.
- **TTFB display**: Request logs list now displays TTFB in seconds (e.g. `5.92s`) with 2 decimal places, flooring values < 10ms to `0.01s`.

## Changes

### Backend — streaming error frame + health failure write-back
- **`crates/core/src/ir/mod.rs`**: Add `UpstreamStreamError` struct and `upstream_error` field to `UsageAccumulator` with `set_upstream_error()` method (first-error-wins semantics)
- **`crates/core/src/telemetry/mod.rs`**: Add `upstream_error: Option<String>` to `ExchangeCapture` so the OLTP sink can mark the request as failed
- **`crates/core/src/lib.rs`**: Re-export `UpstreamStreamError`
- **`crates/server/src/ingress/streaming.rs`**:
  - `detect_verbatim_error()` scans same-protocol SSE bytes for top-level `"error"` JSON keys
  - None branch (upstream clean EOF): inject `encode_done()` (transcode) or `end_marker` (verbatim) when `upstream_error` is set but no terminal signal was seen
  - `StreamCapture` / `StreamCaptureGuard` gain `health` + `health_key` fields
  - `record_health_failure_if_needed()` calls `HealthRegistry::record_failure` on upstream error or gateway-observed truncation (idle/total/upstream_error), called from both `finalize_spawn` and `Drop`
- **`crates/server/src/ingress/executors.rs`**: All 6 streaming `StreamCapture` construction sites now pass `state.health.clone()` and `target.health_key()`
- **`crates/server/src/telemetry.rs`**: Update test helper for new `ExchangeCapture` field
- **`crates/store/src/log_sink/oltp.rs`**: OLTP sink writes failure status when `upstream_error` is present in the capture, using the same upsert strategy as truncation write-back
- **`crates/server/tests/wiremock_providers.rs`**: Integration test verifying HTTP 200 + SSE error frame → client receives `data: [DONE]`

### Frontend — boot screen & skeleton loading
- **`webui/index.html`**: Inline HTML boot splash with animated progress bar, theme-aware colors, and i18n hint text
- **`webui/src/components/BootScreen.tsx`**: New React BootScreen component replacing bare Spinner in Login and ProtectedRoute
- **`webui/src/auth/Login.tsx`**, **`webui/src/auth/ProtectedRoute.tsx`**, **`webui/src/pages/Setup.tsx`**: Use BootScreen instead of Spinner
- **`webui/src/components/TokenHeatmap.tsx`**: Skeleton loading placeholder matching real heatmap layout
- **`webui/src/pages/Settings.tsx`**: Skeleton loading state for settings form
- **`webui/src/i18n/locales/en.ts`**, **`webui/src/i18n/locales/zh.ts`**: Add `bootLoading` translation key

### Frontend — TTFB display
- **`webui/src/pages/RequestLogs.tsx`**: TTFB column now displays seconds with 2 decimal places (`5.92s`), flooring < 10ms to `0.01s`

## Testing
- [x] `make check` — workspace check passes
- [x] `make test` — all workspace tests pass (0 failures)
- [x] `make lint` — rustfmt + clippy `-D warnings` + tsc clean
- [x] 4 new unit tests for health failure write-back (upstream error, clean stream, truncation, client disconnect)
- [x] 1 wiremock integration test for end-frame injection on HTTP 200 + SSE error
- [x] Existing streaming tests remain green

## Breaking Changes
None — the `upstream_error` field is additive on `ExchangeCapture` and `UsageAccumulator`.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests have been added/updated
- [x] No new warnings or errors introduced

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
