### PR TITLE
feat(core): ✨ pass structured error code through to client responses

### DIFF
--- a/crates/core/src/ir/mod.rs
+++ b/crates/core/src/ir/mod.rs
@@ -105,7 +105,15 @@ pub enum StreamPart {
     /// An error occurred during streaming.
     Error {
         message: String,
-        code: Option<String>,
+        /// Normalized error class for protocol-native error type mapping.
+        #[serde(default)]
+        class: crate::routing::ErrorClass,
+        /// Original upstream error code (e.g. `insufficient_quota`,
+        /// `overloaded_error`), preserved for debugging passthrough.
+        /// Not mapped to protocol-native `error.type`; emitted as
+        /// `error.code` in protocols that support it (OpenAI).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        upstream_code: Option<String>,
     },
 }
 
@@ -567,8 +575,12 @@ pub struct UpstreamStreamError {
     /// Human-readable error message extracted from the error frame.
     pub message: String,
     /// Protocol-specific error code/type (e.g. `service_unavailable_error`,
-    /// `overloaded_error`, `429`).
+    /// `overloaded_error`, `429`), preserved for debugging passthrough.
     pub code: Option<String>,
+    /// Normalized error class derived from the upstream code via
+    /// `classify_upstream_error`. Used to drive protocol-native
+    /// error type mapping and fallback decisions.
+    pub class: crate::routing::ErrorClass,
 }
 
 /// Accumulates usage from streaming responses for billing when the
@@ -632,9 +644,11 @@ impl UsageAccumulator {
     /// cause is preserved.
     pub fn set_upstream_error(&mut self, message: &str, code: Option<&str>) {
         if self.upstream_error.is_none() {
+            let class = crate::routing::classify_upstream_error(None, code);
             self.upstream_error = Some(UpstreamStreamError {
                 message: message.to_string(),
                 code: code.map(String::from),
+                class,
             });
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,10 +44,10 @@ pub use provider::{
     AuthApplier, AuthMode, Executor, Provider, ProviderMetadata, ProviderRegistration,
 };
 pub use routing::{
-    classify_error, CooldownStrategy, DefaultFallbackPolicy, ErrorClass, ErrorClassification,
-    FallbackDecision, FallbackPolicy, HealthRegistry, LatencyStrategy, PriorityStrategy,
-    RetryPolicy, RouteEntry, RoutingStrategyName, RoutingTable, RoutingTarget, RoutingTargetHealth,
-    Strategy, WeightedStrategy,
+    classify_error, classify_structured, CooldownStrategy, DefaultFallbackPolicy, ErrorClass,
+    ErrorClassification, FallbackDecision, FallbackPolicy, HealthRegistry, LatencyStrategy,
+    PriorityStrategy, RetryPolicy, RouteEntry, RoutingStrategyName, RoutingTable, RoutingTarget,
+    RoutingTargetHealth, Strategy, WeightedStrategy,
 };
 pub use telemetry::{
     ErrorTier, EventSink, ExchangeCapture, MicroUsd, PipelineEvent, PriceProvider,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,10 +44,11 @@ pub use provider::{
     AuthApplier, AuthMode, Executor, Provider, ProviderMetadata, ProviderRegistration,
 };
 pub use routing::{
-    classify_error, classify_structured, CooldownStrategy, DefaultFallbackPolicy, ErrorClass,
-    ErrorClassification, FallbackDecision, FallbackPolicy, HealthRegistry, LatencyStrategy,
-    PriorityStrategy, RetryPolicy, RouteEntry, RoutingStrategyName, RoutingTable, RoutingTarget,
-    RoutingTargetHealth, Strategy, WeightedStrategy,
+    classify_error, classify_structured, classify_upstream_error, CooldownStrategy,
+    DefaultFallbackPolicy, ErrorClass, ErrorClassification, FallbackDecision, FallbackPolicy,
+    HealthRegistry, LatencyStrategy, PriorityStrategy, RetryPolicy, RouteEntry,
+    RoutingStrategyName, RoutingTable, RoutingTarget, RoutingTargetHealth, Strategy,
+    WeightedStrategy,
 };
 pub use telemetry::{
     ErrorTier, EventSink, ExchangeCapture, MicroUsd, PipelineEvent, PriceProvider,

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -12,6 +12,7 @@ use http::HeaderMap;
 use serde::{Deserialize, Serialize};
 
 use crate::ir::{IrRequest, IrResponse, RawEnvelope, StreamPart};
+use crate::routing::ErrorClass;
 
 /// A protocol suite — the broad family of protocols.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -248,7 +249,16 @@ pub trait StreamEncoder: Send {
     /// Encode a single stream part into protocol-specific bytes.
     fn encode_part(&mut self, part: &StreamPart) -> Result<Vec<u8>, crate::Error>;
     /// Encode an error into the protocol's native error frame.
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8>;
+    ///
+    /// `class` drives the protocol-native `error.type` / `error.status`
+    /// field; `upstream_code` is optionally emitted as `error.code`
+    /// for debugging in protocols that support it (OpenAI).
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        upstream_code: Option<&str>,
+    ) -> Vec<u8>;
     /// Encode a stream-completion signal.
     fn encode_done(&mut self) -> Vec<u8>;
 }

--- a/crates/core/src/routing/mod.rs
+++ b/crates/core/src/routing/mod.rs
@@ -434,10 +434,17 @@ impl HealthRegistry {
     }
 }
 
-/// Error classification for fallback decisions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Error classification for fallback decisions and protocol-native
+/// error type mapping. This enum is the canonical intermediate
+/// representation between opaque upstream error codes and the
+/// protocol-native `error.type` / `error.status` fields emitted to
+/// the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ErrorClass {
+    // --- Upstream error classification (existing) ---
     /// Transient error (5xx, timeout, transport) — may retry/transfer.
+    #[default]
     Transient,
     /// Rate limited (429) — transfer to different target, apply cooling.
     RateLimited,
@@ -447,6 +454,22 @@ pub enum ErrorClass {
     BadRequest,
     /// Capability mismatch (lossy conversion or unsupported feature).
     LossyOrCapability,
+
+    // --- Gateway-originated error classification (new) ---
+    /// No route found for the requested virtual model (404).
+    ModelNotFound,
+    /// Gateway deadline exceeded / timeout (504).
+    DeadlineExceeded,
+    /// All upstream targets exhausted without success (502).
+    UpstreamExhausted,
+    /// Inbound API key missing when `require_api_key` is on (401).
+    AuthMissing,
+    /// Inbound API key did not match any active key (401).
+    AuthInvalid,
+    /// Inbound API key matched a disabled / revoked key (403).
+    AuthDisabled,
+    /// Gateway is overloaded / queue full (503).
+    Overloaded,
 }
 
 impl ErrorClass {
@@ -459,6 +482,31 @@ impl ErrorClass {
             Self::Auth => RequestErrorClass::UpstreamAuth,
             Self::BadRequest => RequestErrorClass::BadRequest,
             Self::LossyOrCapability => RequestErrorClass::LossyOrCapability,
+            Self::ModelNotFound => RequestErrorClass::RouteNotFound,
+            Self::DeadlineExceeded => RequestErrorClass::DeadlineExceeded,
+            Self::UpstreamExhausted => RequestErrorClass::UpstreamExhausted,
+            Self::AuthMissing => RequestErrorClass::AuthMissing,
+            Self::AuthInvalid => RequestErrorClass::AuthInvalid,
+            Self::AuthDisabled => RequestErrorClass::AuthDisabled,
+            Self::Overloaded => RequestErrorClass::InternalError,
+        }
+    }
+
+    /// Map this class to the canonical HTTP status code.
+    pub fn http_status(self) -> u16 {
+        match self {
+            Self::Transient => 502,
+            Self::RateLimited => 429,
+            Self::Auth => 401,
+            Self::BadRequest => 400,
+            Self::LossyOrCapability => 400,
+            Self::ModelNotFound => 404,
+            Self::DeadlineExceeded => 504,
+            Self::UpstreamExhausted => 502,
+            Self::AuthMissing => 401,
+            Self::AuthInvalid => 401,
+            Self::AuthDisabled => 403,
+            Self::Overloaded => 503,
         }
     }
 }
@@ -726,9 +774,19 @@ impl FallbackPolicy for DefaultFallbackPolicy {
                 // Don't retry same account; TryNext will skip same-account targets
                 FallbackDecision::TryNext
             }
-            ErrorClass::BadRequest | ErrorClass::LossyOrCapability => {
-                // Fail immediately
+            ErrorClass::BadRequest
+            | ErrorClass::LossyOrCapability
+            | ErrorClass::ModelNotFound
+            | ErrorClass::AuthMissing
+            | ErrorClass::AuthInvalid
+            | ErrorClass::AuthDisabled
+            | ErrorClass::UpstreamExhausted => {
+                // Fail immediately — retrying won't help
                 FallbackDecision::Fail
+            }
+            ErrorClass::DeadlineExceeded | ErrorClass::Overloaded => {
+                // Retryable with backoff — try next target
+                FallbackDecision::TryNext
             }
         }
     }
@@ -787,92 +845,98 @@ pub fn classify_error(error: &crate::Error) -> ErrorClassification {
     }
 }
 
-/// Classify an error using structured fields (HTTP status + error code)
-/// instead of substring matching on the message text. Used by the
-/// fallback layer when `AppError` carries `upstream_status` and/or
-/// `upstream_error_code` from the upstream response.
+/// Classify an upstream error into an `ErrorClass` using structured
+/// fields (HTTP status + error code). This is the single source of
+/// truth for upstream error normalization.
 ///
-/// Falls back to `Transient` when neither field yields a match, which
-/// is safe because the caller only invokes this when at least one
-/// structured field is `Some`.
-pub fn classify_structured(
+/// Classification priority:
+/// 1. HTTP status exact match for well-known codes.
+/// 2. Error code substring match (case-insensitive) for provider-native codes.
+/// 3. Default: `Transient`.
+pub fn classify_upstream_error(
     upstream_status: Option<u16>,
     upstream_code: Option<&str>,
-) -> ErrorClassification {
+) -> ErrorClass {
     // 1. HTTP status takes priority for well-known codes.
     if let Some(status) = upstream_status {
         match status {
-            429 => {
-                return ErrorClassification {
-                    class: RequestErrorClass::RateLimited,
-                    fallback_class: ErrorClass::RateLimited,
-                    retry_after: None,
-                    http_status: Some(429),
-                }
-            }
-            401 | 403 => {
-                return ErrorClassification {
-                    class: RequestErrorClass::UpstreamAuth,
-                    fallback_class: ErrorClass::Auth,
-                    retry_after: None,
-                    http_status: Some(status),
-                }
-            }
-            400 | 422 => {
-                return ErrorClassification {
-                    class: RequestErrorClass::BadRequest,
-                    fallback_class: ErrorClass::BadRequest,
-                    retry_after: None,
-                    http_status: Some(status),
-                }
-            }
+            429 => return ErrorClass::RateLimited,
+            401 | 403 => return ErrorClass::Auth,
+            400 | 422 => return ErrorClass::BadRequest,
+            404 => return ErrorClass::ModelNotFound,
+            503 => return ErrorClass::Overloaded,
+            504 => return ErrorClass::DeadlineExceeded,
             _ if status >= 500 => {} // fall through to code check
             _ => {}
         }
     }
 
-    // 2. Structured error code substring match (provider-native codes
-    //    vary wildly, so we do case-insensitive substring scanning).
+    // 2. Error code substring match (case-insensitive). Provider-native
+    //    codes vary wildly, so we do case-insensitive substring scanning.
     if let Some(code) = upstream_code {
         let lower = code.to_lowercase();
-        if lower.contains("rate_limit") || lower == "429" {
-            return ErrorClassification {
-                class: RequestErrorClass::RateLimited,
-                fallback_class: ErrorClass::RateLimited,
-                retry_after: None,
-                http_status: Some(429),
-            };
+        if lower.contains("rate_limit")
+            || lower.contains("quota")
+            || lower == "429"
+            || lower == "resource_exhausted"
+        {
+            return ErrorClass::RateLimited;
         }
-        if lower.contains("auth") || lower == "401" || lower == "403" {
-            return ErrorClassification {
-                class: RequestErrorClass::UpstreamAuth,
-                fallback_class: ErrorClass::Auth,
-                retry_after: None,
-                http_status: None,
-            };
+        if lower.contains("auth")
+            || lower == "401"
+            || lower == "403"
+            || lower.contains("invalid_api_key")
+            || lower.contains("permission")
+            || lower.contains("unauthenticated")
+        {
+            return ErrorClass::Auth;
         }
-        if lower.contains("bad_request") || lower == "400" {
-            return ErrorClassification {
-                class: RequestErrorClass::BadRequest,
-                fallback_class: ErrorClass::BadRequest,
-                retry_after: None,
-                http_status: None,
-            };
+        if lower.contains("bad_request")
+            || lower == "400"
+            || lower.contains("invalid_argument")
+            || lower.contains("invalid_request")
+        {
+            return ErrorClass::BadRequest;
         }
-        if lower.contains("overloaded") || lower.contains("service_unavailable") {
-            return ErrorClassification {
-                class: RequestErrorClass::Transient,
-                fallback_class: ErrorClass::Transient,
-                retry_after: None,
-                http_status: None,
-            };
+        if lower.contains("overloaded")
+            || lower.contains("service_unavailable")
+            || lower == "529"
+            || lower == "503"
+            || lower == "unavailable"
+        {
+            return ErrorClass::Overloaded;
+        }
+        if lower.contains("timeout") || lower.contains("deadline") {
+            return ErrorClass::DeadlineExceeded;
+        }
+        if lower.contains("not_found")
+            || lower.contains("model_not_found")
+            || lower == "404"
+        {
+            return ErrorClass::ModelNotFound;
         }
     }
 
     // 3. Default: transient (5xx, timeout, transport)
+    ErrorClass::Transient
+}
+
+/// Classify an error using structured fields (HTTP status + error code)
+/// instead of substring matching on the message text. Used by the
+/// fallback layer when `AppError` carries `upstream_status` and/or
+/// `upstream_error_code` from the upstream response.
+///
+/// Delegates to `classify_upstream_error` for the `ErrorClass` and
+/// maps it to the full `ErrorClassification` with the corresponding
+/// `RequestErrorClass` and HTTP status.
+pub fn classify_structured(
+    upstream_status: Option<u16>,
+    upstream_code: Option<&str>,
+) -> ErrorClassification {
+    let fallback_class = classify_upstream_error(upstream_status, upstream_code);
     ErrorClassification {
-        class: RequestErrorClass::Transient,
-        fallback_class: ErrorClass::Transient,
+        class: fallback_class.to_request_class(),
+        fallback_class,
         retry_after: None,
         http_status: upstream_status,
     }

--- a/crates/core/src/routing/mod.rs
+++ b/crates/core/src/routing/mod.rs
@@ -786,3 +786,94 @@ pub fn classify_error(error: &crate::Error) -> ErrorClassification {
         http_status: None,
     }
 }
+
+/// Classify an error using structured fields (HTTP status + error code)
+/// instead of substring matching on the message text. Used by the
+/// fallback layer when `AppError` carries `upstream_status` and/or
+/// `upstream_error_code` from the upstream response.
+///
+/// Falls back to `Transient` when neither field yields a match, which
+/// is safe because the caller only invokes this when at least one
+/// structured field is `Some`.
+pub fn classify_structured(
+    upstream_status: Option<u16>,
+    upstream_code: Option<&str>,
+) -> ErrorClassification {
+    // 1. HTTP status takes priority for well-known codes.
+    if let Some(status) = upstream_status {
+        match status {
+            429 => {
+                return ErrorClassification {
+                    class: RequestErrorClass::RateLimited,
+                    fallback_class: ErrorClass::RateLimited,
+                    retry_after: None,
+                    http_status: Some(429),
+                }
+            }
+            401 | 403 => {
+                return ErrorClassification {
+                    class: RequestErrorClass::UpstreamAuth,
+                    fallback_class: ErrorClass::Auth,
+                    retry_after: None,
+                    http_status: Some(status),
+                }
+            }
+            400 | 422 => {
+                return ErrorClassification {
+                    class: RequestErrorClass::BadRequest,
+                    fallback_class: ErrorClass::BadRequest,
+                    retry_after: None,
+                    http_status: Some(status),
+                }
+            }
+            _ if status >= 500 => {} // fall through to code check
+            _ => {}
+        }
+    }
+
+    // 2. Structured error code substring match (provider-native codes
+    //    vary wildly, so we do case-insensitive substring scanning).
+    if let Some(code) = upstream_code {
+        let lower = code.to_lowercase();
+        if lower.contains("rate_limit") || lower == "429" {
+            return ErrorClassification {
+                class: RequestErrorClass::RateLimited,
+                fallback_class: ErrorClass::RateLimited,
+                retry_after: None,
+                http_status: Some(429),
+            };
+        }
+        if lower.contains("auth") || lower == "401" || lower == "403" {
+            return ErrorClassification {
+                class: RequestErrorClass::UpstreamAuth,
+                fallback_class: ErrorClass::Auth,
+                retry_after: None,
+                http_status: None,
+            };
+        }
+        if lower.contains("bad_request") || lower == "400" {
+            return ErrorClassification {
+                class: RequestErrorClass::BadRequest,
+                fallback_class: ErrorClass::BadRequest,
+                retry_after: None,
+                http_status: None,
+            };
+        }
+        if lower.contains("overloaded") || lower.contains("service_unavailable") {
+            return ErrorClassification {
+                class: RequestErrorClass::Transient,
+                fallback_class: ErrorClass::Transient,
+                retry_after: None,
+                http_status: None,
+            };
+        }
+    }
+
+    // 3. Default: transient (5xx, timeout, transport)
+    ErrorClassification {
+        class: RequestErrorClass::Transient,
+        fallback_class: ErrorClass::Transient,
+        retry_after: None,
+        http_status: upstream_status,
+    }
+}

--- a/crates/core/src/telemetry/mod.rs
+++ b/crates/core/src/telemetry/mod.rs
@@ -378,6 +378,14 @@ pub struct ExchangeCapture {
     /// request as failed despite the 200 status. `None` for clean
     /// streams and non-stream exchanges.
     pub upstream_error: Option<String>,
+    /// When `upstream_error` is set, this carries the canonical
+    /// `RequestErrorClass` string (e.g. `"transient"`,
+    /// `"rate_limited"`, `"deadline_exceeded"`) derived from the
+    /// upstream error code. The OLTP sink uses this to populate
+    /// `request_logs.error_class` instead of hardcoding
+    /// `"transient"`. `None` for clean streams and non-stream
+    /// exchanges.
+    pub upstream_error_class: Option<String>,
 }
 
 /// The telemetry bus — decouples event production from consumption.

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -342,9 +342,10 @@ mod tests {
         let c = classify_structured(None, Some("rate_limit_exceeded"));
         assert_eq!(c.fallback_class, ErrorClass::RateLimited);
 
-        // Code "overloaded_error" → Transient
+        // Code "overloaded_error" → Overloaded
         let c = classify_structured(None, Some("overloaded_error"));
-        assert_eq!(c.fallback_class, ErrorClass::Transient);
+        assert_eq!(c.fallback_class, ErrorClass::Overloaded);
+        assert_eq!(c.class, RequestErrorClass::InternalError);
 
         // Code "authentication_error" → Auth
         let c = classify_structured(None, Some("authentication_error"));
@@ -353,6 +354,68 @@ mod tests {
         // No status, no code → Transient fallback
         let c = classify_structured(None, None);
         assert_eq!(c.fallback_class, ErrorClass::Transient);
+    }
+
+    #[test]
+    fn test_classify_upstream_error() {
+        use crate::routing::classify_upstream_error;
+
+        // HTTP status takes priority
+        assert_eq!(
+            classify_upstream_error(Some(429), None),
+            ErrorClass::RateLimited
+        );
+        assert_eq!(classify_upstream_error(Some(401), None), ErrorClass::Auth);
+        assert_eq!(classify_upstream_error(Some(403), None), ErrorClass::Auth);
+        assert_eq!(
+            classify_upstream_error(Some(400), None),
+            ErrorClass::BadRequest
+        );
+        assert_eq!(
+            classify_upstream_error(Some(404), None),
+            ErrorClass::ModelNotFound
+        );
+        assert_eq!(
+            classify_upstream_error(Some(504), None),
+            ErrorClass::DeadlineExceeded
+        );
+        assert_eq!(
+            classify_upstream_error(Some(500), None),
+            ErrorClass::Transient
+        );
+
+        // Code substring matching
+        assert_eq!(
+            classify_upstream_error(None, Some("rate_limit_exceeded")),
+            ErrorClass::RateLimited
+        );
+        assert_eq!(
+            classify_upstream_error(None, Some("insufficient_quota")),
+            ErrorClass::RateLimited
+        );
+        assert_eq!(
+            classify_upstream_error(None, Some("invalid_api_key")),
+            ErrorClass::Auth
+        );
+        assert_eq!(
+            classify_upstream_error(None, Some("overloaded_error")),
+            ErrorClass::Overloaded
+        );
+        assert_eq!(
+            classify_upstream_error(None, Some("deadline_exceeded")),
+            ErrorClass::DeadlineExceeded
+        );
+        assert_eq!(
+            classify_upstream_error(None, Some("model_not_found")),
+            ErrorClass::ModelNotFound
+        );
+
+        // Default
+        assert_eq!(classify_upstream_error(None, None), ErrorClass::Transient);
+        assert_eq!(
+            classify_upstream_error(None, Some("unknown_code")),
+            ErrorClass::Transient
+        );
     }
 
     #[test]

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -317,6 +317,45 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_structured() {
+        // HTTP status 429 → RateLimited
+        let c = classify_structured(Some(429), None);
+        assert_eq!(c.fallback_class, ErrorClass::RateLimited);
+        assert_eq!(c.class, RequestErrorClass::RateLimited);
+
+        // HTTP status 401 → Auth
+        let c = classify_structured(Some(401), None);
+        assert_eq!(c.fallback_class, ErrorClass::Auth);
+        assert_eq!(c.class, RequestErrorClass::UpstreamAuth);
+
+        // HTTP status 400 → BadRequest
+        let c = classify_structured(Some(400), None);
+        assert_eq!(c.fallback_class, ErrorClass::BadRequest);
+        assert_eq!(c.class, RequestErrorClass::BadRequest);
+
+        // HTTP status 500 + no code → Transient
+        let c = classify_structured(Some(500), None);
+        assert_eq!(c.fallback_class, ErrorClass::Transient);
+        assert_eq!(c.class, RequestErrorClass::Transient);
+
+        // Code "rate_limit_exceeded" with no status → RateLimited
+        let c = classify_structured(None, Some("rate_limit_exceeded"));
+        assert_eq!(c.fallback_class, ErrorClass::RateLimited);
+
+        // Code "overloaded_error" → Transient
+        let c = classify_structured(None, Some("overloaded_error"));
+        assert_eq!(c.fallback_class, ErrorClass::Transient);
+
+        // Code "authentication_error" → Auth
+        let c = classify_structured(None, Some("authentication_error"));
+        assert_eq!(c.fallback_class, ErrorClass::Auth);
+
+        // No status, no code → Transient fallback
+        let c = classify_structured(None, None);
+        assert_eq!(c.fallback_class, ErrorClass::Transient);
+    }
+
+    #[test]
     fn test_fallback_policy_bytes_emitted() {
         let policy = DefaultFallbackPolicy::with_defaults();
         let target = RoutingTarget {

--- a/crates/protocols/src/chat_completions.rs
+++ b/crates/protocols/src/chat_completions.rs
@@ -7,10 +7,31 @@ use http::HeaderMap;
 use serde_json::{json, Value};
 
 use tiygate_core::{
-    Content, EndpointCapabilities, EndpointCodec, FinishReason, IrRequest, IrResponse, Message,
-    ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder, StreamPart,
-    Tool, Usage,
+    Content, EndpointCapabilities, EndpointCodec, ErrorClass, FinishReason, IrRequest, IrResponse,
+    Message, ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder,
+    StreamPart, Tool, Usage,
 };
+
+/// Map an `ErrorClass` to the OpenAI-native `error.type` string.
+///
+/// This mapping table is shared by `encode_part` (streaming error frames)
+/// and `encode_error_body` (non-streaming error responses).
+fn error_type_for_class(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "server_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "server_error",
+        ErrorClass::UpstreamExhausted => "server_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
 
 /// Chat Completions protocol identity.
 pub const CHAT_COMPLETIONS_ID: ProtocolEndpoint = ProtocolEndpoint {
@@ -518,6 +539,7 @@ impl EndpointCodec for ChatCompletionsCodec {
             tiygate_core::PassThroughPolicy::Convert
         }
     }
+
 
     fn encode_request(
         &self,
@@ -1180,10 +1202,14 @@ impl StreamEncoder for ChatCompletionsStreamEncoder {
                 )
             }
             StreamPart::ResponseCompleted { .. } => "data: [DONE]\n\n".to_string(),
-            StreamPart::Error { message, code } => {
+            StreamPart::Error {
+                message,
+                class,
+                upstream_code,
+            } => {
                 // Protocol-native error frame
-                let mut err = json!({"message": message, "type": "gateway_error"});
-                if let Some(c) = code {
+                let mut err = json!({"message": message, "type": error_type_for_class(*class)});
+                if let Some(c) = upstream_code {
                     err["code"] = json!(c);
                 }
                 format!("data: {}\n\n", json!({"error": err}))
@@ -1193,9 +1219,14 @@ impl StreamEncoder for ChatCompletionsStreamEncoder {
         Ok(chunk.into_bytes())
     }
 
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
-        let mut err = json!({"message": message, "type": "gateway_error"});
-        if let Some(c) = code {
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        upstream_code: Option<&str>,
+    ) -> Vec<u8> {
+        let mut err = json!({"message": message, "type": error_type_for_class(class)});
+        if let Some(c) = upstream_code {
             err["code"] = json!(c);
         }
         format!("data: {}\n\ndata: [DONE]\n\n", json!({"error": err})).into_bytes()
@@ -1306,12 +1337,16 @@ impl StreamDecoder for ChatCompletionsStreamDecoder {
 
                 // Handle error (can appear in any chunk)
                 if let Some(error) = chunk.get("error") {
+                    let code = error["code"].as_str().or_else(|| error["type"].as_str());
+                    let upstream_code = code.map(String::from);
+                    let class = tiygate_core::classify_upstream_error(None, code);
                     parts.push(StreamPart::Error {
                         message: error["message"]
                             .as_str()
                             .unwrap_or("Unknown error")
                             .to_string(),
-                        code: error["code"].as_str().map(String::from),
+                        class,
+                        upstream_code,
                     });
                     return Ok(parts);
                 }
@@ -1486,12 +1521,16 @@ impl StreamDecoder for ChatCompletionsStreamDecoder {
             }
             Some("error") => {
                 let error = &chunk["error"];
+                let code = error["code"].as_str().or_else(|| error["type"].as_str());
+                let upstream_code = code.map(String::from);
+                let class = tiygate_core::classify_upstream_error(None, code);
                 parts.push(StreamPart::Error {
                     message: error["message"]
                         .as_str()
                         .unwrap_or("Unknown error")
                         .to_string(),
-                    code: error["code"].as_str().map(String::from),
+                    class,
+                    upstream_code,
                 });
             }
             Some(_other) => {
@@ -1888,12 +1927,19 @@ mod tests {
     #[test]
     fn test_stream_encoder_error_frame() {
         let mut encoder = ChatCompletionsStreamEncoder::new();
-        let err_bytes = encoder.encode_error("rate limit exceeded", Some("429"));
+        let err_bytes = encoder.encode_error(
+            "rate limit exceeded",
+            ErrorClass::RateLimited,
+            Some("429"),
+        );
         let err_str = String::from_utf8_lossy(&err_bytes);
         // Must contain "error" — protocol-native error frame
         assert!(err_str.contains("error"));
         assert!(err_str.contains("rate limit exceeded"));
-        // code must be transparently passed through to the wire
+        // type must be the OpenAI-native rate_limit_error, not gateway_error
+        assert!(err_str.contains("\"type\":\"rate_limit_error\""));
+        assert!(!err_str.contains("gateway_error"));
+        // upstream code is transparently passed through to error.code
         assert!(err_str.contains("\"code\":\"429\""));
     }
 
@@ -1927,7 +1973,8 @@ mod tests {
             },
             StreamPart::Error {
                 message: "err".to_string(),
-                code: Some("500".to_string()),
+                class: ErrorClass::Transient,
+                upstream_code: Some("500".to_string()),
             },
             StreamPart::ResponseCompleted {
                 id: "r1".to_string(),
@@ -2076,9 +2123,14 @@ mod tests {
         let parts = decoder.feed(line).unwrap();
         assert_eq!(parts.len(), 1);
         match &parts[0] {
-            StreamPart::Error { message, code } => {
+            StreamPart::Error {
+                message,
+                class,
+                upstream_code,
+            } => {
                 assert!(message.contains("rate limit"));
-                assert_eq!(code.as_deref(), Some("429"));
+                assert_eq!(*class, ErrorClass::RateLimited);
+                assert_eq!(upstream_code.as_deref(), Some("429"));
             }
             other => panic!("expected Error, got {:?}", other),
         }

--- a/crates/protocols/src/chat_completions.rs
+++ b/crates/protocols/src/chat_completions.rs
@@ -1180,34 +1180,25 @@ impl StreamEncoder for ChatCompletionsStreamEncoder {
                 )
             }
             StreamPart::ResponseCompleted { .. } => "data: [DONE]\n\n".to_string(),
-            StreamPart::Error { message, code: _ } => {
+            StreamPart::Error { message, code } => {
                 // Protocol-native error frame
-                format!(
-                    "data: {}\n\n",
-                    json!({
-                        "error": {
-                            "message": message,
-                            "type": "gateway_error",
-                        }
-                    })
-                )
+                let mut err = json!({"message": message, "type": "gateway_error"});
+                if let Some(c) = code {
+                    err["code"] = json!(c);
+                }
+                format!("data: {}\n\n", json!({"error": err}))
             }
         };
 
         Ok(chunk.into_bytes())
     }
 
-    fn encode_error(&mut self, message: &str, _code: Option<&str>) -> Vec<u8> {
-        format!(
-            "data: {}\n\ndata: [DONE]\n\n",
-            json!({
-                "error": {
-                    "message": message,
-                    "type": "gateway_error",
-                }
-            })
-        )
-        .into_bytes()
+    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
+        let mut err = json!({"message": message, "type": "gateway_error"});
+        if let Some(c) = code {
+            err["code"] = json!(c);
+        }
+        format!("data: {}\n\ndata: [DONE]\n\n", json!({"error": err})).into_bytes()
     }
 
     fn encode_done(&mut self) -> Vec<u8> {
@@ -1465,10 +1456,9 @@ impl StreamDecoder for ChatCompletionsStreamDecoder {
                         let total = usage["total_tokens"]
                             .as_u64()
                             .unwrap_or(raw_prompt + completion);
-                        let cache_read =
-                            usage["prompt_tokens_details"]["cached_tokens"].as_u64();
-                        let reasoning = usage["completion_tokens_details"]["reasoning_tokens"]
-                            .as_u64();
+                        let cache_read = usage["prompt_tokens_details"]["cached_tokens"].as_u64();
+                        let reasoning =
+                            usage["completion_tokens_details"]["reasoning_tokens"].as_u64();
                         // OpenAI's prompt_tokens includes cache; the IR convention
                         // keeps prompt_tokens cache-free. Subtract to avoid double
                         // counting on re-encode.
@@ -1903,6 +1893,8 @@ mod tests {
         // Must contain "error" — protocol-native error frame
         assert!(err_str.contains("error"));
         assert!(err_str.contains("rate limit exceeded"));
+        // code must be transparently passed through to the wire
+        assert!(err_str.contains("\"code\":\"429\""));
     }
 
     #[test]
@@ -2365,10 +2357,7 @@ mod tests {
             .feed(r#"data: {"id":"r1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"}}],"usage":null}"#)
             .unwrap();
         let has_usage = parts.iter().any(|p| matches!(p, StreamPart::Usage { .. }));
-        assert!(
-            !has_usage,
-            "null usage must not produce StreamPart::Usage"
-        );
+        assert!(!has_usage, "null usage must not produce StreamPart::Usage");
 
         // 2. finish chunk 带 `"usage": null` — 仍不应产出 Usage
         let parts = dec

--- a/crates/protocols/src/embeddings.rs
+++ b/crates/protocols/src/embeddings.rs
@@ -188,10 +188,12 @@ impl StreamEncoder for EmbeddingsStreamEncoder {
     fn encode_part(&mut self, _part: &StreamPart) -> Result<Vec<u8>, tiygate_core::Error> {
         Ok(Vec::new())
     }
-    fn encode_error(&mut self, message: &str, _code: Option<&str>) -> Vec<u8> {
-        json!({"error": {"message": message}})
-            .to_string()
-            .into_bytes()
+    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
+        let mut err = json!({"message": message});
+        if let Some(c) = code {
+            err["code"] = json!(c);
+        }
+        json!({"error": err}).to_string().into_bytes()
     }
     fn encode_done(&mut self) -> Vec<u8> {
         b"data: [DONE]\n\n".to_vec()

--- a/crates/protocols/src/embeddings.rs
+++ b/crates/protocols/src/embeddings.rs
@@ -6,10 +6,28 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use tiygate_core::{
-    Content, EndpointCapabilities, EndpointCodec, FinishReason, IrRequest, IrResponse, Message,
-    ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder, StreamPart,
-    Usage,
+    Content, EndpointCapabilities, EndpointCodec, ErrorClass, FinishReason, IrRequest, IrResponse,
+    Message, ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder,
+    StreamPart, Usage,
 };
+
+/// Map an `ErrorClass` to the OpenAI-native `error.type` string.
+fn error_type_for_class(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "server_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "server_error",
+        ErrorClass::UpstreamExhausted => "server_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
 
 pub struct EmbeddingsCodec {
     id: ProtocolEndpoint,
@@ -181,6 +199,7 @@ impl EndpointCodec for EmbeddingsCodec {
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
         Box::new(EmbeddingsStreamDecoder)
     }
+
 }
 
 pub struct EmbeddingsStreamEncoder;
@@ -188,9 +207,14 @@ impl StreamEncoder for EmbeddingsStreamEncoder {
     fn encode_part(&mut self, _part: &StreamPart) -> Result<Vec<u8>, tiygate_core::Error> {
         Ok(Vec::new())
     }
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
-        let mut err = json!({"message": message});
-        if let Some(c) = code {
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        upstream_code: Option<&str>,
+    ) -> Vec<u8> {
+        let mut err = json!({"message": message, "type": error_type_for_class(class)});
+        if let Some(c) = upstream_code {
             err["code"] = json!(c);
         }
         json!({"error": err}).to_string().into_bytes()

--- a/crates/protocols/src/error_body.rs
+++ b/crates/protocols/src/error_body.rs
@@ -1,0 +1,119 @@
+//! Protocol-native error body generation without a codec instance.
+//!
+//! Provides a standalone function that maps `(ProtocolSuite, ErrorClass)`
+//! to the protocol-native error JSON body. This is used by the HTTP error
+//! response path (`AppError::into_response`) where a codec instance is not
+//! available but the `ProtocolSuite` is known from the ingress endpoint.
+//!
+//! The mapping tables here mirror the `error_type_for_class` / `error_status_for_class`
+//! functions in each protocol codec module. They are the single source of truth
+//! for the non-streaming error body format.
+
+use serde_json::{json, Value};
+use tiygate_core::{ErrorClass, ProtocolSuite};
+
+/// Map an `ErrorClass` to the OpenAI-native `error.type` string.
+fn openai_error_type(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "server_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "server_error",
+        ErrorClass::UpstreamExhausted => "server_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
+
+/// Map an `ErrorClass` to the Anthropic-native `error.type` string.
+fn anthropic_error_type(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "api_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "timeout_error",
+        ErrorClass::UpstreamExhausted => "overloaded_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
+
+/// Map an `ErrorClass` to the Gemini-native `error.status` string.
+fn gemini_error_status(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "INTERNAL",
+        ErrorClass::RateLimited => "RESOURCE_EXHAUSTED",
+        ErrorClass::Auth => "UNAUTHENTICATED",
+        ErrorClass::BadRequest => "INVALID_ARGUMENT",
+        ErrorClass::LossyOrCapability => "FAILED_PRECONDITION",
+        ErrorClass::ModelNotFound => "NOT_FOUND",
+        ErrorClass::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        ErrorClass::UpstreamExhausted => "UNAVAILABLE",
+        ErrorClass::AuthMissing => "UNAUTHENTICATED",
+        ErrorClass::AuthInvalid => "UNAUTHENTICATED",
+        ErrorClass::AuthDisabled => "PERMISSION_DENIED",
+        ErrorClass::Overloaded => "UNAVAILABLE",
+    }
+}
+
+/// Generate a protocol-native error JSON body for the given suite.
+///
+/// This function produces the same JSON structure that the corresponding
+/// codec's `encode_error_body` method would produce, but without requiring
+/// a codec instance. It is used by the HTTP error response path where only
+/// the `ProtocolSuite` is known.
+///
+/// - **OpenAI** (ChatCompletions / Responses / Embeddings / Images):
+///   `{"error":{"message":"...","type":"...","param":null,"code":"..."}}`
+/// - **Anthropic**: `{"type":"error","error":{"type":"...","message":"..."}}`
+/// - **Gemini**: `{"error":{"code":<http_status>,"message":"...","status":"...","details":[]}}`
+pub fn encode_error_body_for_suite(
+    suite: ProtocolSuite,
+    message: &str,
+    class: ErrorClass,
+    http_status: u16,
+    upstream_code: Option<&str>,
+) -> Value {
+    match suite {
+        ProtocolSuite::OpenAiCompatible | ProtocolSuite::OpenAiResponses => {
+            let mut err = json!({
+                "message": message,
+                "type": openai_error_type(class),
+                "param": null,
+            });
+            if let Some(c) = upstream_code {
+                err["code"] = json!(c);
+            }
+            json!({"error": err})
+        }
+        ProtocolSuite::AnthropicMessages => {
+            json!({
+                "type": "error",
+                "error": {
+                    "type": anthropic_error_type(class),
+                    "message": message,
+                }
+            })
+        }
+        ProtocolSuite::GoogleGemini => {
+            json!({
+                "error": {
+                    "code": http_status,
+                    "message": message,
+                    "status": gemini_error_status(class),
+                    "details": []
+                }
+            })
+        }
+    }
+}

--- a/crates/protocols/src/gemini.rs
+++ b/crates/protocols/src/gemini.rs
@@ -1225,10 +1225,13 @@ impl StreamEncoder for GeminiStreamEncoder {
                     json!({"candidates": [{"finishReason": fr}]})
                 )
             }
-            StreamPart::Error { message, .. } => format!(
-                "data: {}\n\n",
-                json!({"error": {"message": message, "status": "INTERNAL"}})
-            ),
+            StreamPart::Error { message, code } => {
+                let status = code.as_deref().unwrap_or("INTERNAL");
+                format!(
+                    "data: {}\n\n",
+                    json!({"error": {"message": message, "status": status}})
+                )
+            }
             StreamPart::ResponseStarted { id } => {
                 format!("data: {}\n\n", json!({"responseId": id}))
             }
@@ -1238,10 +1241,11 @@ impl StreamEncoder for GeminiStreamEncoder {
         };
         Ok(chunk.into_bytes())
     }
-    fn encode_error(&mut self, message: &str, _code: Option<&str>) -> Vec<u8> {
+    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
+        let status = code.unwrap_or("INTERNAL");
         format!(
             "data: {}\n\n",
-            json!({"error": {"message": message, "status": "INTERNAL"}})
+            json!({"error": {"message": message, "status": status}})
         )
         .into_bytes()
     }
@@ -1547,6 +1551,9 @@ mod tests {
         let s = String::from_utf8_lossy(&err);
         assert!(s.contains("error"));
         assert!(s.contains("rate limit"));
+        // code must replace hardcoded INTERNAL
+        assert!(s.contains("\"status\":\"429\""));
+        assert!(!s.contains("\"status\":\"INTERNAL\""));
     }
 
     #[test]

--- a/crates/protocols/src/gemini.rs
+++ b/crates/protocols/src/gemini.rs
@@ -5,10 +5,29 @@ use http::HeaderMap;
 use serde_json::{json, Value};
 
 use tiygate_core::{
-    Content, EndpointCapabilities, EndpointCodec, FinishReason, IrRequest, IrResponse, Message,
-    ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder, StreamPart,
-    Tool, Usage,
+    Content, EndpointCapabilities, EndpointCodec, ErrorClass, FinishReason, IrRequest, IrResponse,
+    Message, ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder,
+    StreamPart, Tool, Usage,
 };
+
+/// Map an `ErrorClass` to the Google Gemini-native `error.status` string
+/// (google.rpc.Code enum name).
+fn error_status_for_class(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "INTERNAL",
+        ErrorClass::RateLimited => "RESOURCE_EXHAUSTED",
+        ErrorClass::Auth => "UNAUTHENTICATED",
+        ErrorClass::BadRequest => "INVALID_ARGUMENT",
+        ErrorClass::LossyOrCapability => "FAILED_PRECONDITION",
+        ErrorClass::ModelNotFound => "NOT_FOUND",
+        ErrorClass::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        ErrorClass::UpstreamExhausted => "UNAVAILABLE",
+        ErrorClass::AuthMissing => "UNAUTHENTICATED",
+        ErrorClass::AuthInvalid => "UNAUTHENTICATED",
+        ErrorClass::AuthDisabled => "PERMISSION_DENIED",
+        ErrorClass::Overloaded => "UNAVAILABLE",
+    }
+}
 
 /// Maximum value for Gemini's `thinkingBudget` field (0–24576).
 const GEMINI_THINKING_BUDGET_MAX: u32 = 24576;
@@ -1150,6 +1169,7 @@ impl EndpointCodec for GeminiCodec {
             tiygate_core::PassThroughPolicy::Convert
         }
     }
+
 }
 
 pub struct GeminiStreamEncoder;
@@ -1225,8 +1245,12 @@ impl StreamEncoder for GeminiStreamEncoder {
                     json!({"candidates": [{"finishReason": fr}]})
                 )
             }
-            StreamPart::Error { message, code } => {
-                let status = code.as_deref().unwrap_or("INTERNAL");
+            StreamPart::Error {
+                message,
+                class,
+                upstream_code: _,
+            } => {
+                let status = error_status_for_class(*class);
                 format!(
                     "data: {}\n\n",
                     json!({"error": {"message": message, "status": status}})
@@ -1241,8 +1265,13 @@ impl StreamEncoder for GeminiStreamEncoder {
         };
         Ok(chunk.into_bytes())
     }
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
-        let status = code.unwrap_or("INTERNAL");
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        _upstream_code: Option<&str>,
+    ) -> Vec<u8> {
+        let status = error_status_for_class(class);
         format!(
             "data: {}\n\n",
             json!({"error": {"message": message, "status": status}})
@@ -1325,12 +1354,15 @@ impl StreamDecoder for GeminiStreamDecoder {
             }
         }
         if event.get("error").is_some() {
+            let code = event["error"]["status"].as_str();
+            let class = tiygate_core::classify_upstream_error(None, code);
             parts.push(StreamPart::Error {
                 message: event["error"]["message"]
                     .as_str()
                     .unwrap_or("Unknown")
                     .to_string(),
-                code: event["error"]["status"].as_str().map(String::from),
+                class,
+                upstream_code: code.map(String::from),
             });
             return Ok(parts);
         }
@@ -1547,12 +1579,13 @@ mod tests {
     #[test]
     fn test_stream_encoder_error_frame() {
         let mut encoder = GeminiStreamEncoder;
-        let err = encoder.encode_error("rate limit", Some("429"));
+        let err = encoder.encode_error("rate limit", ErrorClass::RateLimited, None);
         let s = String::from_utf8_lossy(&err);
         assert!(s.contains("error"));
         assert!(s.contains("rate limit"));
-        // code must replace hardcoded INTERNAL
-        assert!(s.contains("\"status\":\"429\""));
+        // status must be the Gemini-native RESOURCE_EXHAUSTED, not "429"
+        assert!(s.contains("\"status\":\"RESOURCE_EXHAUSTED\""));
+        assert!(!s.contains("\"status\":\"429\""));
         assert!(!s.contains("\"status\":\"INTERNAL\""));
     }
 
@@ -1584,7 +1617,8 @@ mod tests {
             },
             StreamPart::Error {
                 message: "e".to_string(),
-                code: Some("500".to_string()),
+                class: ErrorClass::Transient,
+                upstream_code: Some("500".to_string()),
             },
             StreamPart::ResponseCompleted {
                 id: "r1".to_string(),

--- a/crates/protocols/src/images.rs
+++ b/crates/protocols/src/images.rs
@@ -19,9 +19,28 @@ use http::HeaderMap;
 use serde_json::{json, Value};
 
 use tiygate_core::{
-    EndpointCapabilities, EndpointCodec, Error, IrRequest, IrResponse, PassThroughPolicy,
-    ProtocolEndpoint, ProtocolSuite, RawEnvelope, StreamDecoder, StreamEncoder, StreamPart,
+    EndpointCapabilities, EndpointCodec, Error, ErrorClass, IrRequest, IrResponse,
+    PassThroughPolicy, ProtocolEndpoint, ProtocolSuite, RawEnvelope, StreamDecoder, StreamEncoder,
+    StreamPart,
 };
+
+/// Map an `ErrorClass` to the OpenAI-native `error.type` string.
+fn error_type_for_class(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "server_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "server_error",
+        ErrorClass::UpstreamExhausted => "server_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
 
 // ---------------------------------------------------------------------------
 // ImagesGenerationsCodec
@@ -199,6 +218,7 @@ impl EndpointCodec for ImagesGenerationsCodec {
             PassThroughPolicy::Convert
         }
     }
+
 }
 
 // ---------------------------------------------------------------------------
@@ -371,6 +391,7 @@ impl EndpointCodec for ImagesEditsCodec {
             PassThroughPolicy::Convert
         }
     }
+
 }
 
 // ---------------------------------------------------------------------------
@@ -423,18 +444,31 @@ impl StreamEncoder for ImagesStreamEncoder {
                 }
                 Ok(format!("data: {}\n\n", Value::Object(payload)).into_bytes())
             }
-            StreamPart::Error { message, code } => Ok(self.encode_error(message, code.as_deref())),
+            StreamPart::Error {
+                message,
+                class,
+                upstream_code,
+            } => Ok(self.encode_error(message, *class, upstream_code.as_deref())),
             _ => Ok(Vec::new()),
         }
     }
 
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        upstream_code: Option<&str>,
+    ) -> Vec<u8> {
+        let mut error_obj = json!({
+            "message": message,
+            "type": error_type_for_class(class),
+        });
+        if let Some(c) = upstream_code {
+            error_obj["code"] = json!(c);
+        }
         let payload = json!({
             "type": "error",
-            "error": {
-                "message": message,
-                "code": code.unwrap_or("upstream_error"),
-            },
+            "error": error_obj,
         });
         format!("data: {}\n\n", payload).into_bytes()
     }
@@ -510,13 +544,15 @@ impl StreamDecoder for ImagesStreamDecoder {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown error")
                     .to_string();
+                let code = value
+                    .get("error")
+                    .and_then(|e| e.get("code"))
+                    .and_then(|v| v.as_str());
+                let class = tiygate_core::classify_upstream_error(None, code);
                 Ok(vec![StreamPart::Error {
                     message: msg,
-                    code: value
-                        .get("error")
-                        .and_then(|e| e.get("code"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                    class,
+                    upstream_code: code.map(String::from),
                 }])
             }
             _ => Ok(Vec::new()),
@@ -680,11 +716,16 @@ mod tests {
     #[test]
     fn test_stream_encoder_error() {
         let mut enc = ImagesStreamEncoder::new();
-        let frame = enc.encode_error("test error", Some("test_code"));
+        let frame = enc.encode_error(
+            "test error",
+            ErrorClass::RateLimited,
+            Some("test_code"),
+        );
         let s = String::from_utf8(frame).unwrap();
         assert!(s.contains("\"type\":\"error\""));
         assert!(s.contains("test error"));
         assert!(s.contains("test_code"));
+        assert!(s.contains("\"type\":\"rate_limit_error\""));
     }
 
     #[test]

--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod chat_completions;
 pub mod embeddings;
+pub mod error_body;
 pub mod gemini;
 pub mod images;
 pub mod messages;

--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -7,10 +7,28 @@ use http::HeaderMap;
 use serde_json::{json, Value};
 
 use tiygate_core::{
-    Content, EndpointCapabilities, EndpointCodec, FinishReason, IrRequest, IrResponse, Message,
-    ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder, StreamPart,
-    Tool, Usage,
+    Content, EndpointCapabilities, EndpointCodec, ErrorClass, FinishReason, IrRequest, IrResponse,
+    Message, ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder,
+    StreamPart, Tool, Usage,
 };
+
+/// Map an `ErrorClass` to the Anthropic-native `error.type` string.
+fn error_type_for_class(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "api_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "timeout_error",
+        ErrorClass::UpstreamExhausted => "overloaded_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
 
 /// Flatten an Anthropic `tool_result.content` value into a plain string.
 ///
@@ -903,6 +921,7 @@ impl EndpointCodec for MessagesCodec {
             tiygate_core::PassThroughPolicy::Convert
         }
     }
+
 }
 
 // --- Stream Encoder (Anthropic SSE) ---
@@ -1147,11 +1166,12 @@ impl StreamEncoder for MessagesStreamEncoder {
                 ));
                 out
             }
-            StreamPart::Error { message, code } => {
-                let mut err = json!({"type": "gateway_error", "message": message});
-                if let Some(c) = code {
-                    err["code"] = json!(c);
-                }
+            StreamPart::Error {
+                message,
+                class,
+                upstream_code: _,
+            } => {
+                let err = json!({"type": error_type_for_class(*class), "message": message});
                 format!(
                     "event: error\ndata: {}\n\n",
                     json!({"type": "error", "error": err})
@@ -1162,11 +1182,13 @@ impl StreamEncoder for MessagesStreamEncoder {
         Ok(event.into_bytes())
     }
 
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
-        let mut err = json!({"type": "gateway_error", "message": message});
-        if let Some(c) = code {
-            err["code"] = json!(c);
-        }
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        _upstream_code: Option<&str>,
+    ) -> Vec<u8> {
+        let err = json!({"type": error_type_for_class(class), "message": message});
         format!(
             "event: error\ndata: {}\n\n",
             json!({"type": "error", "error": err})
@@ -1491,12 +1513,15 @@ impl StreamDecoder for MessagesStreamDecoder {
                 });
             }
             Some("error") => {
+                let code = event["error"]["type"].as_str();
+                let class = tiygate_core::classify_upstream_error(None, code);
                 parts.push(StreamPart::Error {
                     message: event["error"]["message"]
                         .as_str()
                         .unwrap_or("Unknown error")
                         .to_string(),
-                    code: event["error"]["type"].as_str().map(String::from),
+                    class,
+                    upstream_code: code.map(String::from),
                 });
             }
             Some(_other) => {
@@ -1817,13 +1842,14 @@ mod tests {
     #[test]
     fn test_stream_encoder_error_frame() {
         let mut encoder = MessagesStreamEncoder::new();
-        let err_bytes = encoder.encode_error("overloaded", Some("529"));
+        let err_bytes = encoder.encode_error("overloaded", ErrorClass::Overloaded, None);
         let err_str = String::from_utf8_lossy(&err_bytes);
         // Must contain "error" — protocol-native error frame
         assert!(err_str.contains("error"));
         assert!(err_str.contains("overloaded"));
-        // code must be transparently passed through to the wire
-        assert!(err_str.contains("\"code\":\"529\""));
+        // type must be Anthropic-native overloaded_error, not gateway_error
+        assert!(err_str.contains("\"type\":\"overloaded_error\""));
+        assert!(!err_str.contains("gateway_error"));
     }
 
     #[test]
@@ -1854,7 +1880,8 @@ mod tests {
             },
             StreamPart::Error {
                 message: "err".to_string(),
-                code: Some("500".to_string()),
+                class: ErrorClass::Transient,
+                upstream_code: Some("500".to_string()),
             },
             StreamPart::ResponseCompleted {
                 id: "r1".to_string(),

--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -1147,10 +1147,14 @@ impl StreamEncoder for MessagesStreamEncoder {
                 ));
                 out
             }
-            StreamPart::Error { message, code: _ } => {
+            StreamPart::Error { message, code } => {
+                let mut err = json!({"type": "gateway_error", "message": message});
+                if let Some(c) = code {
+                    err["code"] = json!(c);
+                }
                 format!(
                     "event: error\ndata: {}\n\n",
-                    json!({"type": "error", "error": {"type": "gateway_error", "message": message}})
+                    json!({"type": "error", "error": err})
                 )
             }
         };
@@ -1158,10 +1162,14 @@ impl StreamEncoder for MessagesStreamEncoder {
         Ok(event.into_bytes())
     }
 
-    fn encode_error(&mut self, message: &str, _code: Option<&str>) -> Vec<u8> {
+    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
+        let mut err = json!({"type": "gateway_error", "message": message});
+        if let Some(c) = code {
+            err["code"] = json!(c);
+        }
         format!(
             "event: error\ndata: {}\n\n",
-            json!({"type": "error", "error": {"type": "gateway_error", "message": message}})
+            json!({"type": "error", "error": err})
         )
         .into_bytes()
     }
@@ -1814,6 +1822,8 @@ mod tests {
         // Must contain "error" — protocol-native error frame
         assert!(err_str.contains("error"));
         assert!(err_str.contains("overloaded"));
+        // code must be transparently passed through to the wire
+        assert!(err_str.contains("\"code\":\"529\""));
     }
 
     #[test]

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -772,13 +772,11 @@ impl EndpointCodec for ResponsesCodec {
                                 // `function_call_output` input item. Preserve
                                 // them regardless of the IR message role so
                                 // prior function calls have matching outputs.
-                                tool_outputs_json.push(
-                                    responses_function_call_output(
-                                        tool_call_id,
-                                        content,
-                                        id.as_deref(),
-                                    ),
-                                );
+                                tool_outputs_json.push(responses_function_call_output(
+                                    tool_call_id,
+                                    content,
+                                    id.as_deref(),
+                                ));
                             }
                             Content::Refusal { text, .. } => {
                                 text_parts.push(json!({"type": "input_text", "text": text}));
@@ -1568,16 +1566,24 @@ impl StreamEncoder for ResponsesStreamEncoder {
                 out.push_str("data: [DONE]\n\n");
                 out
             }
-            StreamPart::Error { message, .. } => self.event(
-                json!({"type": "error", "error": {"message": message, "type": "gateway_error"}}),
-            ),
+            StreamPart::Error { message, code } => {
+                let mut err = json!({"message": message, "type": "gateway_error"});
+                if let Some(c) = code {
+                    err["code"] = json!(c);
+                }
+                self.event(json!({"type": "error", "error": err}))
+            }
         };
         Ok(chunk.into_bytes())
     }
-    fn encode_error(&mut self, message: &str, _code: Option<&str>) -> Vec<u8> {
+    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
+        let mut err = json!({"message": message, "type": "gateway_error"});
+        if let Some(c) = code {
+            err["code"] = json!(c);
+        }
         format!(
             "data: {}\n\ndata: [DONE]\n\n",
-            json!({"type": "error", "error": {"message": message, "type": "gateway_error"}})
+            json!({"type": "error", "error": err})
         )
         .into_bytes()
     }
@@ -2278,6 +2284,8 @@ mod tests {
         let s = String::from_utf8_lossy(&err);
         assert!(s.contains("error"));
         assert!(s.contains("overloaded"));
+        // code must be transparently passed through to the wire
+        assert!(s.contains("\"code\":\"529\""));
     }
 
     #[test]

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -6,10 +6,29 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use tiygate_core::{
-    Content, EndpointCapabilities, EndpointCodec, FinishReason, IrRequest, IrResponse, Message,
-    ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder, StreamPart,
-    Tool, Usage,
+    Content, EndpointCapabilities, EndpointCodec, ErrorClass, FinishReason, IrRequest, IrResponse,
+    Message, ProtocolEndpoint, ProtocolSuite, RawEnvelope, Role, StreamDecoder, StreamEncoder,
+    StreamPart, Tool, Usage,
 };
+
+/// Map an `ErrorClass` to the OpenAI Responses-native `error.type` string.
+/// Uses the same mapping as ChatCompletions (both are OpenAI family).
+fn error_type_for_class(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "server_error",
+        ErrorClass::RateLimited => "rate_limit_error",
+        ErrorClass::Auth => "authentication_error",
+        ErrorClass::BadRequest => "invalid_request_error",
+        ErrorClass::LossyOrCapability => "invalid_request_error",
+        ErrorClass::ModelNotFound => "not_found_error",
+        ErrorClass::DeadlineExceeded => "server_error",
+        ErrorClass::UpstreamExhausted => "server_error",
+        ErrorClass::AuthMissing => "authentication_error",
+        ErrorClass::AuthInvalid => "authentication_error",
+        ErrorClass::AuthDisabled => "permission_error",
+        ErrorClass::Overloaded => "overloaded_error",
+    }
+}
 
 pub struct ResponsesCodec {
     id: ProtocolEndpoint,
@@ -1146,6 +1165,7 @@ impl EndpointCodec for ResponsesCodec {
             tiygate_core::PassThroughPolicy::Convert
         }
     }
+
 }
 
 pub struct ResponsesStreamEncoder {
@@ -1566,9 +1586,13 @@ impl StreamEncoder for ResponsesStreamEncoder {
                 out.push_str("data: [DONE]\n\n");
                 out
             }
-            StreamPart::Error { message, code } => {
-                let mut err = json!({"message": message, "type": "gateway_error"});
-                if let Some(c) = code {
+            StreamPart::Error {
+                message,
+                class,
+                upstream_code,
+            } => {
+                let mut err = json!({"message": message, "type": error_type_for_class(*class)});
+                if let Some(c) = upstream_code {
                     err["code"] = json!(c);
                 }
                 self.event(json!({"type": "error", "error": err}))
@@ -1576,9 +1600,14 @@ impl StreamEncoder for ResponsesStreamEncoder {
         };
         Ok(chunk.into_bytes())
     }
-    fn encode_error(&mut self, message: &str, code: Option<&str>) -> Vec<u8> {
-        let mut err = json!({"message": message, "type": "gateway_error"});
-        if let Some(c) = code {
+    fn encode_error(
+        &mut self,
+        message: &str,
+        class: ErrorClass,
+        upstream_code: Option<&str>,
+    ) -> Vec<u8> {
+        let mut err = json!({"message": message, "type": error_type_for_class(class)});
+        if let Some(c) = upstream_code {
             err["code"] = json!(c);
         }
         format!(
@@ -1872,9 +1901,12 @@ impl StreamDecoder for ResponsesStreamDecoder {
                 } else {
                     &event["response"]["error"]
                 };
+                let code = err["type"].as_str();
+                let class = tiygate_core::classify_upstream_error(None, code);
                 parts.push(StreamPart::Error {
                     message: err["message"].as_str().unwrap_or("Unknown").to_string(),
-                    code: err["type"].as_str().map(String::from),
+                    class,
+                    upstream_code: code.map(String::from),
                 });
             }
             Some("response.incomplete") => {
@@ -2280,12 +2312,12 @@ mod tests {
     #[test]
     fn test_stream_encoder_error_frame() {
         let mut encoder = ResponsesStreamEncoder::new();
-        let err = encoder.encode_error("overloaded", Some("529"));
+        let err = encoder.encode_error("overloaded", ErrorClass::Overloaded, None);
         let s = String::from_utf8_lossy(&err);
         assert!(s.contains("error"));
         assert!(s.contains("overloaded"));
-        // code must be transparently passed through to the wire
-        assert!(s.contains("\"code\":\"529\""));
+        assert!(s.contains("\"type\":\"overloaded_error\""));
+        assert!(!s.contains("gateway_error"));
     }
 
     #[test]

--- a/crates/protocols/tests/images.rs
+++ b/crates/protocols/tests/images.rs
@@ -226,11 +226,16 @@ fn test_stream_encoder_done_marker() {
 #[test]
 fn test_stream_encoder_error_frame() {
     let mut enc = tiygate_protocols::images::ImagesStreamEncoder::new();
-    let frame = enc.encode_error("test error", Some("test_code"));
+    let frame = enc.encode_error(
+        "test error",
+        tiygate_core::ErrorClass::RateLimited,
+        Some("test_code"),
+    );
     let s = String::from_utf8(frame).unwrap();
     assert!(s.contains("\"type\":\"error\""));
     assert!(s.contains("test error"));
     assert!(s.contains("test_code"));
+    assert!(s.contains("\"type\":\"rate_limit_error\""));
 }
 
 #[test]

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -63,11 +63,15 @@ fn check_nonstream_error_body(
     let message = error["message"]
         .as_str()
         .unwrap_or("upstream returned error in 200 response body");
+    let code = error["code"].as_str().or_else(|| error["type"].as_str());
     let mut app_err = AppError::new(
         StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
         format!("Upstream error: {}", message),
     );
     app_err.upstream_status = Some(status);
+    if let Some(c) = code {
+        app_err = app_err.with_code(c);
+    }
     if let Some(ra) = retry_after {
         app_err = app_err.with_retry_after_header(ra);
     }
@@ -272,6 +276,7 @@ pub(super) async fn execute_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -422,6 +427,7 @@ pub(super) async fn execute_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -434,6 +440,12 @@ pub(super) async fn execute_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+            if let Some(c) = response_body["error"]["code"]
+                .as_str()
+                .or_else(|| response_body["error"]["type"].as_str())
+            {
+                app_err = app_err.with_code(c);
+            }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -467,6 +479,7 @@ pub(super) async fn execute_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             return Err(app_err);
@@ -542,6 +555,7 @@ pub(super) async fn execute_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         Ok((response, ttfb_ms))
@@ -708,6 +722,7 @@ pub(super) async fn execute_messages_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -834,6 +849,7 @@ pub(super) async fn execute_messages_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -846,6 +862,12 @@ pub(super) async fn execute_messages_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+            if let Some(c) = response_body["error"]["code"]
+                .as_str()
+                .or_else(|| response_body["error"]["type"].as_str())
+            {
+                app_err = app_err.with_code(c);
+            }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -878,6 +900,7 @@ pub(super) async fn execute_messages_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             return Err(app_err);
@@ -945,6 +968,7 @@ pub(super) async fn execute_messages_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         Ok((response, ttfb_ms))
@@ -1160,9 +1184,10 @@ pub(super) async fn execute_embeddings_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
-        let app_err = AppError::new(
+        let mut app_err = AppError::new(
             StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
             format!(
                 "Upstream error: {}",
@@ -1171,6 +1196,13 @@ pub(super) async fn execute_embeddings_upstream(
                     .unwrap_or("Unknown error")
             ),
         );
+        app_err.upstream_status = Some(status.as_u16());
+        if let Some(c) = response_body["error"]["code"]
+            .as_str()
+            .or_else(|| response_body["error"]["type"].as_str())
+        {
+            app_err = app_err.with_code(c);
+        }
         return Err(app_err);
     }
 
@@ -1196,6 +1228,7 @@ pub(super) async fn execute_embeddings_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         return Err(app_err);
@@ -1226,6 +1259,7 @@ pub(super) async fn execute_embeddings_upstream(
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         },
     );
 
@@ -1378,6 +1412,7 @@ pub(super) async fn execute_responses_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -1508,6 +1543,7 @@ pub(super) async fn execute_responses_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         let mut app_err = AppError::new(
@@ -1515,6 +1551,12 @@ pub(super) async fn execute_responses_upstream(
             format!("Upstream {}: {}", status, response_body),
         );
         app_err.upstream_status = Some(status.as_u16());
+        if let Some(c) = response_body["error"]["code"]
+            .as_str()
+            .or_else(|| response_body["error"]["type"].as_str())
+        {
+            app_err = app_err.with_code(c);
+        }
         if let Some(ra) = retry_after {
             app_err = app_err.with_retry_after_header(ra);
         }
@@ -1547,6 +1589,7 @@ pub(super) async fn execute_responses_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         return Err(app_err);
@@ -1613,6 +1656,7 @@ pub(super) async fn execute_responses_upstream(
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         },
     );
     Ok((resp, ttfb_ms))
@@ -1783,6 +1827,7 @@ pub(super) async fn execute_gemini_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -1913,6 +1958,7 @@ pub(super) async fn execute_gemini_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         let mut app_err = AppError::new(
@@ -1920,6 +1966,12 @@ pub(super) async fn execute_gemini_upstream(
             format!("Upstream {}: {}", status, response_body),
         );
         app_err.upstream_status = Some(status.as_u16());
+        if let Some(c) = response_body["error"]["code"]
+            .as_str()
+            .or_else(|| response_body["error"]["type"].as_str())
+        {
+            app_err = app_err.with_code(c);
+        }
         if let Some(ra) = retry_after {
             app_err = app_err.with_retry_after_header(ra);
         }
@@ -1952,6 +2004,7 @@ pub(super) async fn execute_gemini_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         return Err(app_err);
@@ -2018,6 +2071,7 @@ pub(super) async fn execute_gemini_upstream(
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         },
     );
     Ok((resp, ttfb_ms))
@@ -2150,6 +2204,7 @@ pub(super) async fn execute_images_generations_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2284,6 +2339,7 @@ pub(super) async fn execute_images_generations_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2296,6 +2352,12 @@ pub(super) async fn execute_images_generations_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+            if let Some(c) = response_body["error"]["code"]
+                .as_str()
+                .or_else(|| response_body["error"]["type"].as_str())
+            {
+                app_err = app_err.with_code(c);
+            }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -2328,6 +2390,7 @@ pub(super) async fn execute_images_generations_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             return Err(app_err);
@@ -2400,6 +2463,7 @@ pub(super) async fn execute_images_generations_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         Ok((response, ttfb_ms))
@@ -2484,6 +2548,7 @@ pub(super) async fn execute_images_edits_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2613,6 +2678,7 @@ pub(super) async fn execute_images_edits_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             let mut app_err = AppError::new(
@@ -2625,6 +2691,12 @@ pub(super) async fn execute_images_edits_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+            if let Some(c) = response_body["error"]["code"]
+                .as_str()
+                .or_else(|| response_body["error"]["type"].as_str())
+            {
+                app_err = app_err.with_code(c);
+            }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -2657,6 +2729,7 @@ pub(super) async fn execute_images_edits_upstream(
                     truncation_reason: None,
                     stream_duration_ms: None,
                     upstream_error: None,
+                    upstream_error_class: None,
                 },
             );
             return Err(app_err);
@@ -2702,6 +2775,7 @@ pub(super) async fn execute_images_edits_upstream(
                 truncation_reason: None,
                 stream_duration_ms: None,
                 upstream_error: None,
+                upstream_error_class: None,
             },
         );
         Ok((response, ttfb_ms))

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -69,8 +69,10 @@ fn check_nonstream_error_body(
         format!("Upstream error: {}", message),
     );
     app_err.upstream_status = Some(status);
+    let class = tiygate_core::classify_upstream_error(Some(status), code);
+    app_err = app_err.with_class(class);
     if let Some(c) = code {
-        app_err = app_err.with_code(c);
+        app_err = app_err.with_upstream_code(c);
     }
     if let Some(ra) = retry_after {
         app_err = app_err.with_retry_after_header(ra);
@@ -284,6 +286,7 @@ pub(super) async fn execute_upstream(
                 format!("Upstream {}: {}", status, error_body),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -306,7 +309,7 @@ pub(super) async fn execute_upstream(
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
-            Some("upstream_timeout"),
+            tiygate_core::ErrorClass::DeadlineExceeded, None,
         );
 
         let forwarded_resp_headers = forwarded_resp_headers_for_capture(
@@ -440,11 +443,12 @@ pub(super) async fn execute_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(c) = response_body["error"]["code"]
                 .as_str()
                 .or_else(|| response_body["error"]["type"].as_str())
             {
-                app_err = app_err.with_code(c);
+                app_err = app_err.with_upstream_code(c);
             }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
@@ -730,6 +734,7 @@ pub(super) async fn execute_messages_upstream(
                 format!("Upstream {}: {}", status, error_body),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -748,7 +753,7 @@ pub(super) async fn execute_messages_upstream(
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
-            Some("upstream_timeout"),
+            tiygate_core::ErrorClass::DeadlineExceeded, None,
         );
 
         let forwarded_resp_headers = forwarded_resp_headers_for_capture(
@@ -862,11 +867,12 @@ pub(super) async fn execute_messages_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(c) = response_body["error"]["code"]
                 .as_str()
                 .or_else(|| response_body["error"]["type"].as_str())
             {
-                app_err = app_err.with_code(c);
+                app_err = app_err.with_upstream_code(c);
             }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
@@ -1197,11 +1203,12 @@ pub(super) async fn execute_embeddings_upstream(
             ),
         );
         app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
         if let Some(c) = response_body["error"]["code"]
             .as_str()
             .or_else(|| response_body["error"]["type"].as_str())
         {
-            app_err = app_err.with_code(c);
+            app_err = app_err.with_upstream_code(c);
         }
         return Err(app_err);
     }
@@ -1420,6 +1427,7 @@ pub(super) async fn execute_responses_upstream(
                 format!("Upstream {}: {}", status, error_body),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -1432,7 +1440,7 @@ pub(super) async fn execute_responses_upstream(
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
-            Some("upstream_timeout"),
+            tiygate_core::ErrorClass::DeadlineExceeded, None,
         );
 
         let mut response = drive_upstream_stream(
@@ -1551,11 +1559,12 @@ pub(super) async fn execute_responses_upstream(
             format!("Upstream {}: {}", status, response_body),
         );
         app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
         if let Some(c) = response_body["error"]["code"]
             .as_str()
             .or_else(|| response_body["error"]["type"].as_str())
         {
-            app_err = app_err.with_code(c);
+            app_err = app_err.with_upstream_code(c);
         }
         if let Some(ra) = retry_after {
             app_err = app_err.with_retry_after_header(ra);
@@ -1835,6 +1844,7 @@ pub(super) async fn execute_gemini_upstream(
                 format!("Upstream {}: {}", status, error_body),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -1847,7 +1857,7 @@ pub(super) async fn execute_gemini_upstream(
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
-            Some("upstream_timeout"),
+            tiygate_core::ErrorClass::DeadlineExceeded, None,
         );
 
         let mut response = drive_upstream_stream(
@@ -1966,11 +1976,12 @@ pub(super) async fn execute_gemini_upstream(
             format!("Upstream {}: {}", status, response_body),
         );
         app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
         if let Some(c) = response_body["error"]["code"]
             .as_str()
             .or_else(|| response_body["error"]["type"].as_str())
         {
-            app_err = app_err.with_code(c);
+            app_err = app_err.with_upstream_code(c);
         }
         if let Some(ra) = retry_after {
             app_err = app_err.with_retry_after_header(ra);
@@ -2212,6 +2223,7 @@ pub(super) async fn execute_images_generations_upstream(
                 format!("Upstream {status}: {error_body}"),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -2227,7 +2239,7 @@ pub(super) async fn execute_images_generations_upstream(
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
-            Some("upstream_timeout"),
+            tiygate_core::ErrorClass::DeadlineExceeded, None,
         );
 
         let forwarded_resp_headers = forwarded_resp_headers_for_capture(
@@ -2352,11 +2364,12 @@ pub(super) async fn execute_images_generations_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(c) = response_body["error"]["code"]
                 .as_str()
                 .or_else(|| response_body["error"]["type"].as_str())
             {
-                app_err = app_err.with_code(c);
+                app_err = app_err.with_upstream_code(c);
             }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
@@ -2556,6 +2569,7 @@ pub(super) async fn execute_images_edits_upstream(
                 format!("Upstream {status}: {error_body}"),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);
             }
@@ -2573,7 +2587,7 @@ pub(super) async fn execute_images_edits_upstream(
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
-            Some("upstream_timeout"),
+            tiygate_core::ErrorClass::DeadlineExceeded, None,
         );
 
         let forwarded_resp_headers = forwarded_resp_headers_for_capture(
@@ -2691,11 +2705,12 @@ pub(super) async fn execute_images_edits_upstream(
                 ),
             );
             app_err.upstream_status = Some(status.as_u16());
+                    app_err = app_err.with_class(tiygate_core::classify_upstream_error(Some(status.as_u16()), None));
             if let Some(c) = response_body["error"]["code"]
                 .as_str()
                 .or_else(|| response_body["error"]["type"].as_str())
             {
-                app_err = app_err.with_code(c);
+                app_err = app_err.with_upstream_code(c);
             }
             if let Some(ra) = retry_after {
                 app_err = app_err.with_retry_after_header(ra);

--- a/crates/server/src/ingress/fallback.rs
+++ b/crates/server/src/ingress/fallback.rs
@@ -142,7 +142,7 @@ where
                 StatusCode::GATEWAY_TIMEOUT,
                 "request deadline exceeded".to_string(),
             )
-            .with_code("deadline_exceeded");
+            .with_class(tiygate_core::ErrorClass::DeadlineExceeded);
             return FallbackOutcome::Failed {
                 error: app_err,
                 error_class: RequestErrorClass::DeadlineExceeded,
@@ -245,9 +245,12 @@ where
                 // available (HTTP status + error code from upstream),
                 // fall back to substring matching on the message.
                 let classification = if app_err.upstream_status.is_some()
-                    || app_err.error_code().is_some()
+                    || app_err.upstream_error_code().is_some()
                 {
-                    tiygate_core::classify_structured(app_err.upstream_status, app_err.error_code())
+                    tiygate_core::classify_structured(
+                        app_err.upstream_status,
+                        app_err.upstream_error_code(),
+                    )
                 } else {
                     let core_err = tiygate_core::Error::Routing(app_err.message.clone());
                     classify_error(&core_err)
@@ -346,7 +349,7 @@ where
             StatusCode::BAD_GATEWAY,
             "all upstream targets exhausted".to_string(),
         )
-        .with_code("upstream_exhausted")
+        .with_class(tiygate_core::ErrorClass::UpstreamExhausted)
     });
     FallbackOutcome::Exhausted { error: final_err }
 }

--- a/crates/server/src/ingress/fallback.rs
+++ b/crates/server/src/ingress/fallback.rs
@@ -141,7 +141,8 @@ where
             let app_err = AppError::new(
                 StatusCode::GATEWAY_TIMEOUT,
                 "request deadline exceeded".to_string(),
-            );
+            )
+            .with_code("deadline_exceeded");
             return FallbackOutcome::Failed {
                 error: app_err,
                 error_class: RequestErrorClass::DeadlineExceeded,
@@ -240,9 +241,17 @@ where
                 state.health.record_failure(&health_key);
                 state.health.record_latency_ms(&health_key, hop_elapsed_ms);
 
-                // Classify the error
-                let core_err = tiygate_core::Error::Routing(app_err.message.clone());
-                let classification = classify_error(&core_err);
+                // Classify the error — prefer structured fields when
+                // available (HTTP status + error code from upstream),
+                // fall back to substring matching on the message.
+                let classification = if app_err.upstream_status.is_some()
+                    || app_err.error_code().is_some()
+                {
+                    tiygate_core::classify_structured(app_err.upstream_status, app_err.error_code())
+                } else {
+                    let core_err = tiygate_core::Error::Routing(app_err.message.clone());
+                    classify_error(&core_err)
+                };
 
                 // Telemetry: HopFailure
                 state
@@ -281,6 +290,7 @@ where
                 }
 
                 // Decide next action
+                let core_err = tiygate_core::Error::Routing(app_err.message.clone());
                 let decision =
                     fallback.classify(&core_err, target, attempt, max_attempts, bytes_emitted);
 
@@ -336,6 +346,7 @@ where
             StatusCode::BAD_GATEWAY,
             "all upstream targets exhausted".to_string(),
         )
+        .with_code("upstream_exhausted")
     });
     FallbackOutcome::Exhausted { error: final_err }
 }

--- a/crates/server/src/ingress/handlers.rs
+++ b/crates/server/src/ingress/handlers.rs
@@ -168,7 +168,7 @@ pub(super) async fn acquire_permit(
             StatusCode::SERVICE_UNAVAILABLE,
             "gateway overloaded, queue full".to_string(),
         )
-        .with_code("gateway_overloaded")
+        .with_class(tiygate_core::ErrorClass::Overloaded)
         .with_retry_after(5));
     }
 
@@ -183,13 +183,13 @@ pub(super) async fn acquire_permit(
             StatusCode::SERVICE_UNAVAILABLE,
             "gateway overloaded".to_string(),
         )
-        .with_code("gateway_overloaded")
+        .with_class(tiygate_core::ErrorClass::Overloaded)
         .with_retry_after(5)),
         Err(_) => Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "gateway too busy, try again later".to_string(),
         )
-        .with_code("gateway_overloaded")
+        .with_class(tiygate_core::ErrorClass::Overloaded)
         .with_retry_after(5)),
     }
 }
@@ -217,6 +217,7 @@ fn emit_early_error(scope: crate::ingress::observability::RequestScope<'_>, err:
 async fn acquire_or_log<'a>(
     state: &'a AppState,
     scope: crate::ingress::observability::RequestScope<'a>,
+    suite: tiygate_core::ProtocolSuite,
 ) -> Result<
     (
         tokio::sync::OwnedSemaphorePermit,
@@ -228,7 +229,7 @@ async fn acquire_or_log<'a>(
         Ok(permit) => Ok((permit, scope)),
         Err(err) => {
             emit_early_error(scope, &err);
-            Err(err)
+            Err(err.with_protocol_suite(suite))
         }
     }
 }
@@ -238,12 +239,13 @@ fn enforce_body_limit_or_log<'a>(
     scope: crate::ingress::observability::RequestScope<'a>,
     content_type: Option<&str>,
     body_size: u64,
+    suite: tiygate_core::ProtocolSuite,
 ) -> Result<crate::ingress::observability::RequestScope<'a>, AppError> {
     match enforce_body_limit(state, content_type, body_size) {
         Ok(()) => Ok(scope),
         Err(err) => {
             emit_early_error(scope, &err);
-            Err(err)
+            Err(err.with_protocol_suite(suite))
         }
     }
 }
@@ -297,8 +299,8 @@ pub(super) async fn handle_chat_completions(
         scope.set_envelope(raw_env.clone());
         scope
     };
-    let (_permit, scope) = acquire_or_log(&state, scope).await?;
-    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size)?;
+    let (_permit, scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
+    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size, codec.id().suite)?;
 
     // Phase 4 §4.6: api key resolution + quota enforcement. The
     // resolved `api_key` is bound to the scope so the terminal
@@ -307,7 +309,7 @@ pub(super) async fn handle_chat_completions(
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     match crate::ingress::observability::check_quota(&state, &api_key.key_id, &api_key.spec, 1)
         .await
@@ -316,7 +318,7 @@ pub(super) async fn handle_chat_completions(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -324,7 +326,7 @@ pub(super) async fn handle_chat_completions(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -337,14 +339,14 @@ pub(super) async fn handle_chat_completions(
         Ok(r) => r,
         Err(e) => {
             let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
-                .with_code("bad_request");
+                .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -361,14 +363,14 @@ pub(super) async fn handle_chat_completions(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -419,7 +421,7 @@ pub(super) async fn handle_chat_completions(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -428,7 +430,7 @@ pub(super) async fn handle_chat_completions(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }
@@ -470,7 +472,7 @@ pub(super) async fn handle_messages(
         scope.set_envelope(raw_env.clone());
         scope
     };
-    let (_permit, mut scope) = acquire_or_log(&state, scope).await?;
+    let (_permit, mut scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
 
     // Phase 4 §4.6: api key resolution + quota enforcement (parity
     // with the chat-completions path). The resolved `api_key` is
@@ -480,7 +482,7 @@ pub(super) async fn handle_messages(
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     match crate::ingress::observability::check_quota(&state, &api_key.key_id, &api_key.spec, 1)
         .await
@@ -489,7 +491,7 @@ pub(super) async fn handle_messages(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -497,7 +499,7 @@ pub(super) async fn handle_messages(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -507,14 +509,14 @@ pub(super) async fn handle_messages(
         Ok(r) => r,
         Err(e) => {
             let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
-                .with_code("bad_request");
+                .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
     let virtual_model = ir_request.model.clone();
@@ -529,14 +531,14 @@ pub(super) async fn handle_messages(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -579,7 +581,7 @@ pub(super) async fn handle_messages(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -588,7 +590,7 @@ pub(super) async fn handle_messages(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }
@@ -633,7 +635,7 @@ pub(super) async fn handle_embeddings(
     // Persist the redacted envelope on the terminal RequestEvent
     // for audit / replay (§8 #3 / #8).
     scope.set_envelope(raw_env.clone());
-    let (_permit, mut scope) = acquire_or_log(&state, scope).await?;
+    let (_permit, mut scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
 
     // Phase 4 §4.6: api key resolution + quota enforcement, parity
     // with the chat/messages/responses/gemini handlers. Embedding
@@ -643,7 +645,7 @@ pub(super) async fn handle_embeddings(
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     match crate::ingress::observability::check_quota(&state, &api_key.key_id, &api_key.spec, 1)
         .await
@@ -652,7 +654,7 @@ pub(super) async fn handle_embeddings(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -660,7 +662,7 @@ pub(super) async fn handle_embeddings(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -723,14 +725,14 @@ pub(super) async fn handle_embeddings(
         Ok(r) => r,
         Err(e) => {
             let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
-                .with_code("bad_request");
+                .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -743,14 +745,14 @@ pub(super) async fn handle_embeddings(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -787,7 +789,7 @@ pub(super) async fn handle_embeddings(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -796,7 +798,7 @@ pub(super) async fn handle_embeddings(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }
@@ -850,15 +852,15 @@ pub(super) async fn handle_responses(
     // Persist the redacted envelope on the terminal RequestEvent
     // for audit / replay (§8 #3 / #8).
     scope.set_envelope(raw_env.clone());
-    let (_permit, scope) = acquire_or_log(&state, scope).await?;
-    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size)?;
+    let (_permit, scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
+    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size, codec.id().suite)?;
     // Bind the api key id so the terminal RequestEvent attributes the
     // row to the right caller (used by the per-key quota dashboard).
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     // Phase 4 §4.6: quota enforcement on the request hot path.
     // Parity with the chat-completions / anthropic-messages paths.
@@ -869,7 +871,7 @@ pub(super) async fn handle_responses(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -877,7 +879,7 @@ pub(super) async fn handle_responses(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -887,14 +889,14 @@ pub(super) async fn handle_responses(
         Ok(r) => r,
         Err(e) => {
             let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
-                .with_code("bad_request");
+                .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -908,14 +910,14 @@ pub(super) async fn handle_responses(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -957,7 +959,7 @@ pub(super) async fn handle_responses(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -966,7 +968,7 @@ pub(super) async fn handle_responses(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }
@@ -1019,34 +1021,34 @@ pub(super) async fn handle_gemini_generate(
                 StatusCode::BAD_REQUEST,
                 format!("Invalid Gemini path capture: {capture:?}"),
             )
-            .with_code("bad_request");
+            .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::BadRequest,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
     let is_gemini_stream = method == "streamGenerateContent";
     let model = model.to_string();
     scope.set_virtual_model(model.clone());
-    let (_permit, scope) = acquire_or_log(&state, scope).await?;
+    let (_permit, scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
     let content_type = headers
         .get(http::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok());
     let body_size = serde_json::to_string(&body)
         .map(|s| s.len() as u64)
         .unwrap_or(0);
-    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size)?;
+    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size, codec.id().suite)?;
     // Bind the api key id so the terminal RequestEvent attributes the
     // row to the right caller (used by the per-key quota dashboard).
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     // Phase 4 §4.6: quota enforcement on the request hot path.
     // Parity with the chat-completions / anthropic-messages paths.
@@ -1057,7 +1059,7 @@ pub(super) async fn handle_gemini_generate(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -1065,7 +1067,7 @@ pub(super) async fn handle_gemini_generate(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -1083,14 +1085,14 @@ pub(super) async fn handle_gemini_generate(
         Ok(r) => r,
         Err(e) => {
             let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
-                .with_code("bad_request");
+                .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -1104,14 +1106,14 @@ pub(super) async fn handle_gemini_generate(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -1153,7 +1155,7 @@ pub(super) async fn handle_gemini_generate(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -1162,7 +1164,7 @@ pub(super) async fn handle_gemini_generate(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }
@@ -1210,14 +1212,14 @@ pub(super) async fn handle_images_generations(
         started,
     );
     scope.set_envelope(raw_env.clone());
-    let (_permit, scope) = acquire_or_log(&state, scope).await?;
-    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size)?;
+    let (_permit, scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
+    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body_size, codec.id().suite)?;
 
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     match crate::ingress::observability::check_quota(&state, &api_key.key_id, &api_key.spec, 1)
         .await
@@ -1226,7 +1228,7 @@ pub(super) async fn handle_images_generations(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -1234,7 +1236,7 @@ pub(super) async fn handle_images_generations(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -1246,14 +1248,14 @@ pub(super) async fn handle_images_generations(
         Ok(r) => r,
         Err(e) => {
             let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
-                .with_code("bad_request");
+                .with_class(tiygate_core::ErrorClass::BadRequest);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -1268,14 +1270,14 @@ pub(super) async fn handle_images_generations(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -1321,7 +1323,7 @@ pub(super) async fn handle_images_generations(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -1330,7 +1332,7 @@ pub(super) async fn handle_images_generations(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }
@@ -1425,14 +1427,14 @@ pub(super) async fn handle_images_edits(
         started,
     );
     scope.set_envelope(raw_env.clone());
-    let (_permit, scope) = acquire_or_log(&state, scope).await?;
-    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body.len() as u64)?;
+    let (_permit, scope) = acquire_or_log(&state, scope, codec.id().suite).await?;
+    let mut scope = enforce_body_limit_or_log(&state, scope, content_type, body.len() as u64, codec.id().suite)?;
 
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
     scope.set_api_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
-        return Err(err);
+        return Err(err.with_protocol_suite(codec.id().suite));
     }
     match crate::ingress::observability::check_quota(&state, &api_key.key_id, &api_key.spec, 1)
         .await
@@ -1441,7 +1443,7 @@ pub(super) async fn handle_images_edits(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
-                    .with_code("rate_limited")
+                    .with_class(tiygate_core::ErrorClass::RateLimited)
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -1449,7 +1451,7 @@ pub(super) async fn handle_images_edits(
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     }
 
@@ -1460,14 +1462,14 @@ pub(super) async fn handle_images_edits(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
             )
-            .with_code("model_not_found");
+            .with_class(tiygate_core::ErrorClass::ModelNotFound);
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
                 Some(&app_err.message),
                 Some(http_status),
             );
-            return Err(app_err);
+            return Err(app_err.with_protocol_suite(codec.id().suite));
         }
     };
 
@@ -1509,7 +1511,7 @@ pub(super) async fn handle_images_edits(
         FallbackOutcome::Failed { error, error_class } => {
             let http_status = error.http_status().as_u16();
             scope.emit_error(error_class, Some(&error.message), Some(http_status));
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
         FallbackOutcome::Exhausted { error } => {
             let http_status = error.http_status().as_u16();
@@ -1518,7 +1520,7 @@ pub(super) async fn handle_images_edits(
                 Some(&error.message),
                 Some(http_status),
             );
-            Err(error)
+            Err(error.with_protocol_suite(codec.id().suite))
         }
     }
 }

--- a/crates/server/src/ingress/handlers.rs
+++ b/crates/server/src/ingress/handlers.rs
@@ -168,6 +168,7 @@ pub(super) async fn acquire_permit(
             StatusCode::SERVICE_UNAVAILABLE,
             "gateway overloaded, queue full".to_string(),
         )
+        .with_code("gateway_overloaded")
         .with_retry_after(5));
     }
 
@@ -182,11 +183,13 @@ pub(super) async fn acquire_permit(
             StatusCode::SERVICE_UNAVAILABLE,
             "gateway overloaded".to_string(),
         )
+        .with_code("gateway_overloaded")
         .with_retry_after(5)),
         Err(_) => Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "gateway too busy, try again later".to_string(),
         )
+        .with_code("gateway_overloaded")
         .with_retry_after(5)),
     }
 }
@@ -313,6 +316,7 @@ pub(super) async fn handle_chat_completions(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -332,7 +336,8 @@ pub(super) async fn handle_chat_completions(
     let ir_request = match codec.decode_request(body, &raw_env) {
         Ok(r) => r,
         Err(e) => {
-            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"));
+            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
+                .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
@@ -355,7 +360,8 @@ pub(super) async fn handle_chat_completions(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
@@ -483,6 +489,7 @@ pub(super) async fn handle_messages(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -499,7 +506,8 @@ pub(super) async fn handle_messages(
     let ir_request = match codec.decode_request(body, &raw_env) {
         Ok(r) => r,
         Err(e) => {
-            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"));
+            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
+                .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
@@ -520,7 +528,8 @@ pub(super) async fn handle_messages(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
@@ -643,6 +652,7 @@ pub(super) async fn handle_embeddings(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -712,7 +722,8 @@ pub(super) async fn handle_embeddings(
     let ir_request = match codec.decode_request(body, &raw_env) {
         Ok(r) => r,
         Err(e) => {
-            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"));
+            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
+                .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
@@ -731,7 +742,8 @@ pub(super) async fn handle_embeddings(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
@@ -857,6 +869,7 @@ pub(super) async fn handle_responses(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -873,7 +886,8 @@ pub(super) async fn handle_responses(
     let ir_request = match codec.decode_request(body, &raw_env) {
         Ok(r) => r,
         Err(e) => {
-            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"));
+            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
+                .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
@@ -893,7 +907,8 @@ pub(super) async fn handle_responses(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
@@ -1003,7 +1018,8 @@ pub(super) async fn handle_gemini_generate(
             let app_err = AppError::new(
                 StatusCode::BAD_REQUEST,
                 format!("Invalid Gemini path capture: {capture:?}"),
-            );
+            )
+            .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::BadRequest,
@@ -1041,6 +1057,7 @@ pub(super) async fn handle_gemini_generate(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -1065,7 +1082,8 @@ pub(super) async fn handle_gemini_generate(
     let ir_request = match codec.decode_request(body, &raw_env) {
         Ok(r) => r,
         Err(e) => {
-            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"));
+            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
+                .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
@@ -1085,7 +1103,8 @@ pub(super) async fn handle_gemini_generate(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
@@ -1207,6 +1226,7 @@ pub(super) async fn handle_images_generations(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -1225,7 +1245,8 @@ pub(super) async fn handle_images_generations(
     let ir_request = match codec.decode_request(body, &raw_env) {
         Ok(r) => r,
         Err(e) => {
-            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"));
+            let app_err = AppError::new(StatusCode::BAD_REQUEST, format!("Decode error: {e}"))
+                .with_code("bad_request");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::DecodeError,
@@ -1246,7 +1267,8 @@ pub(super) async fn handle_images_generations(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,
@@ -1419,6 +1441,7 @@ pub(super) async fn handle_images_edits(
         crate::ingress::observability::QuotaOutcome::Deny { retry_after, .. } => {
             let app_err =
                 AppError::new(StatusCode::TOO_MANY_REQUESTS, "quota exceeded".to_string())
+                    .with_code("rate_limited")
                     .with_retry_after(retry_after.as_secs().max(1));
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
@@ -1436,7 +1459,8 @@ pub(super) async fn handle_images_edits(
             let app_err = AppError::new(
                 StatusCode::NOT_FOUND,
                 format!("No route found for model: {virtual_model}"),
-            );
+            )
+            .with_code("model_not_found");
             let http_status = app_err.http_status().as_u16();
             scope.emit_error(
                 RequestErrorClass::RouteNotFound,

--- a/crates/server/src/ingress/mod.rs
+++ b/crates/server/src/ingress/mod.rs
@@ -1010,6 +1010,11 @@ pub struct AppError {
     retry_after_header: Option<String>,
     /// Original upstream HTTP status for error source distinction.
     upstream_status: Option<u16>,
+    /// Structured error code extracted from upstream `error.code` /
+    /// `error.type`, or a gateway-defined semantic code. Serialized to
+    /// the client JSON as `error.code` so clients can switch on it
+    /// instead of substring-matching `message`.
+    upstream_error_code: Option<String>,
     /// Upstream RateLimit-* headers to passthrough on the error response.
     rate_limit_headers: Vec<(&'static str, String)>,
 }
@@ -1021,8 +1026,23 @@ impl AppError {
             message,
             retry_after_header: None,
             upstream_status: None,
+            upstream_error_code: None,
             rate_limit_headers: Vec::new(),
         }
+    }
+
+    /// Attach a structured error code (e.g. `"rate_limited"`,
+    /// `"upstream_error"`, or a provider-native code like `"429"`).
+    pub(crate) fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.upstream_error_code = Some(code.into());
+        self
+    }
+
+    /// Public accessor for the structured error code, if any.
+    /// Used by the fallback classifier to pick `classify_structured`
+    /// over substring matching.
+    pub(crate) fn error_code(&self) -> Option<&str> {
+        self.upstream_error_code.as_deref()
     }
 
     /// Attach a Retry-After value (seconds).
@@ -1063,6 +1083,10 @@ impl IntoResponse for AppError {
 
         if let Some(us) = self.upstream_status {
             body["error"]["upstream_status"] = serde_json::json!(us);
+        }
+
+        if let Some(ref code) = self.upstream_error_code {
+            body["error"]["code"] = serde_json::json!(code);
         }
 
         let mut response = (self.status, Json(body)).into_response();

--- a/crates/server/src/ingress/mod.rs
+++ b/crates/server/src/ingress/mod.rs
@@ -1006,14 +1006,21 @@ mod streaming_helper_tests {
 pub struct AppError {
     status: StatusCode,
     message: String,
+    /// Normalized error class for protocol-native error type mapping
+    /// and fallback classification. Defaults to `Transient` when not
+    /// explicitly set via `with_class()`.
+    error_class: tiygate_core::ErrorClass,
+    /// The ingress protocol suite, used to generate protocol-native
+    /// error response bodies in `into_response()`. When `None`, falls
+    /// back to a generic OpenAI-style error body.
+    protocol_suite: Option<tiygate_core::ProtocolSuite>,
     /// Passthrough Retry-After header value from upstream.
     retry_after_header: Option<String>,
     /// Original upstream HTTP status for error source distinction.
     upstream_status: Option<u16>,
-    /// Structured error code extracted from upstream `error.code` /
-    /// `error.type`, or a gateway-defined semantic code. Serialized to
-    /// the client JSON as `error.code` so clients can switch on it
-    /// instead of substring-matching `message`.
+    /// Original upstream error code (e.g. `insufficient_quota`,
+    /// `overloaded_error`), preserved for debugging passthrough as
+    /// `error.code` in protocols that support it.
     upstream_error_code: Option<String>,
     /// Upstream RateLimit-* headers to passthrough on the error response.
     rate_limit_headers: Vec<(&'static str, String)>,
@@ -1024,6 +1031,8 @@ impl AppError {
         Self {
             status,
             message,
+            error_class: tiygate_core::ErrorClass::Transient,
+            protocol_suite: None,
             retry_after_header: None,
             upstream_status: None,
             upstream_error_code: None,
@@ -1031,17 +1040,37 @@ impl AppError {
         }
     }
 
-    /// Attach a structured error code (e.g. `"rate_limited"`,
-    /// `"upstream_error"`, or a provider-native code like `"429"`).
-    pub(crate) fn with_code(mut self, code: impl Into<String>) -> Self {
+    /// Attach a normalized error class. This drives both the
+    /// protocol-native `error.type` / `error.status` field in the
+    /// response body and the fallback classifier's retry/stop decision.
+    pub(crate) fn with_class(mut self, class: tiygate_core::ErrorClass) -> Self {
+        self.error_class = class;
+        self
+    }
+
+    /// Attach the ingress protocol suite, enabling protocol-native
+    /// error body generation in `into_response()`.
+    pub(crate) fn with_protocol_suite(
+        mut self,
+        suite: tiygate_core::ProtocolSuite,
+    ) -> Self {
+        self.protocol_suite = Some(suite);
+        self
+    }
+
+    /// Attach an upstream-native error code (e.g. `insufficient_quota`)
+    /// for debugging passthrough as `error.code` in protocols that
+    /// support it (OpenAI). Also influences fallback classification
+    /// when `error_class` has not been explicitly set via `with_class()`.
+    pub(crate) fn with_upstream_code(mut self, code: impl Into<String>) -> Self {
         self.upstream_error_code = Some(code.into());
         self
     }
 
-    /// Public accessor for the structured error code, if any.
+    /// Public accessor for the upstream error code, if any.
     /// Used by the fallback classifier to pick `classify_structured`
     /// over substring matching.
-    pub(crate) fn error_code(&self) -> Option<&str> {
+    pub(crate) fn upstream_error_code(&self) -> Option<&str> {
         self.upstream_error_code.as_deref()
     }
 
@@ -1067,27 +1096,28 @@ impl AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let error_source = if self.upstream_status.is_some() {
-            "upstream"
+        // Generate protocol-native error body when the protocol suite
+        // is known; otherwise fall back to a generic OpenAI-style body.
+        let body = if let Some(suite) = self.protocol_suite {
+            tiygate_protocols::error_body::encode_error_body_for_suite(
+                suite,
+                &self.message,
+                self.error_class,
+                self.status.as_u16(),
+                self.upstream_error_code.as_deref(),
+            )
         } else {
-            "gateway"
-        };
-
-        let mut body = serde_json::json!({
-            "error": {
+            // Fallback: generic OpenAI-style error body.
+            let mut err = serde_json::json!({
                 "message": self.message,
-                "type": "gateway_error",
-                "source": error_source,
+                "type": "server_error",
+                "param": null,
+            });
+            if let Some(ref code) = self.upstream_error_code {
+                err["code"] = serde_json::json!(code);
             }
-        });
-
-        if let Some(us) = self.upstream_status {
-            body["error"]["upstream_status"] = serde_json::json!(us);
-        }
-
-        if let Some(ref code) = self.upstream_error_code {
-            body["error"]["code"] = serde_json::json!(code);
-        }
+            serde_json::json!({"error": err})
+        };
 
         let mut response = (self.status, Json(body)).into_response();
 

--- a/crates/server/src/ingress/observability.rs
+++ b/crates/server/src/ingress/observability.rs
@@ -196,15 +196,18 @@ pub(super) fn enforce_auth(
     match api_key.outcome {
         KeyLookupOutcome::Authenticated => Ok(()),
         KeyLookupOutcome::NoCredential => Err((
-            AppError::new(StatusCode::UNAUTHORIZED, "missing api key".to_string()),
+            AppError::new(StatusCode::UNAUTHORIZED, "missing api key".to_string())
+                .with_code("auth_missing"),
             RequestErrorClass::AuthMissing,
         )),
         KeyLookupOutcome::UnknownCredential => Err((
-            AppError::new(StatusCode::UNAUTHORIZED, "invalid api key".to_string()),
+            AppError::new(StatusCode::UNAUTHORIZED, "invalid api key".to_string())
+                .with_code("auth_invalid"),
             RequestErrorClass::AuthInvalid,
         )),
         KeyLookupOutcome::DisabledCredential => Err((
-            AppError::new(StatusCode::FORBIDDEN, "api key disabled".to_string()),
+            AppError::new(StatusCode::FORBIDDEN, "api key disabled".to_string())
+                .with_code("auth_disabled"),
             RequestErrorClass::AuthDisabled,
         )),
     }

--- a/crates/server/src/ingress/observability.rs
+++ b/crates/server/src/ingress/observability.rs
@@ -197,17 +197,17 @@ pub(super) fn enforce_auth(
         KeyLookupOutcome::Authenticated => Ok(()),
         KeyLookupOutcome::NoCredential => Err((
             AppError::new(StatusCode::UNAUTHORIZED, "missing api key".to_string())
-                .with_code("auth_missing"),
+                .with_class(tiygate_core::ErrorClass::AuthMissing),
             RequestErrorClass::AuthMissing,
         )),
         KeyLookupOutcome::UnknownCredential => Err((
             AppError::new(StatusCode::UNAUTHORIZED, "invalid api key".to_string())
-                .with_code("auth_invalid"),
+                .with_class(tiygate_core::ErrorClass::AuthInvalid),
             RequestErrorClass::AuthInvalid,
         )),
         KeyLookupOutcome::DisabledCredential => Err((
             AppError::new(StatusCode::FORBIDDEN, "api key disabled".to_string())
-                .with_code("auth_disabled"),
+                .with_class(tiygate_core::ErrorClass::AuthDisabled),
             RequestErrorClass::AuthDisabled,
         )),
     }

--- a/crates/server/src/ingress/streaming.rs
+++ b/crates/server/src/ingress/streaming.rs
@@ -383,6 +383,34 @@ impl StreamCaptureGuard {
                 }
             })
         });
+        // Map the upstream error code to a canonical
+        // `RequestErrorClass` string so the OLTP sink can populate
+        // `request_logs.error_class` accurately instead of
+        // hardcoding "transient".
+        let upstream_error_class = self.accum.lock().ok().and_then(|a| {
+            a.upstream_error.as_ref().and_then(|e| {
+                match e.code.as_deref() {
+                    // Gateway-synthesized codes
+                    Some("upstream_timeout") => Some("deadline_exceeded"),
+                    Some("upstream_error") => Some("transient"),
+                    Some("transcode_error") => Some("lossy_or_capability"),
+                    _ => {
+                        // Provider-native codes: substring match
+                        let lower = e.code.as_deref().unwrap_or("").to_lowercase();
+                        if lower.contains("rate_limit") || lower == "429" {
+                            Some("rate_limited")
+                        } else if lower.contains("auth") {
+                            Some("upstream_auth")
+                        } else {
+                            // overloaded, service_unavailable, and
+                            // everything else → transient
+                            Some("transient")
+                        }
+                    }
+                }
+                .map(String::from)
+            })
+        });
         Some((
             telemetry,
             tiygate_core::ExchangeCapture {
@@ -400,6 +428,7 @@ impl StreamCaptureGuard {
                 truncation_reason: state.last_reason.map(|r| r.as_str().to_string()),
                 stream_duration_ms,
                 upstream_error,
+                upstream_error_class,
             },
         ))
     }

--- a/crates/server/src/ingress/streaming.rs
+++ b/crates/server/src/ingress/streaming.rs
@@ -388,27 +388,8 @@ impl StreamCaptureGuard {
         // `request_logs.error_class` accurately instead of
         // hardcoding "transient".
         let upstream_error_class = self.accum.lock().ok().and_then(|a| {
-            a.upstream_error.as_ref().and_then(|e| {
-                match e.code.as_deref() {
-                    // Gateway-synthesized codes
-                    Some("upstream_timeout") => Some("deadline_exceeded"),
-                    Some("upstream_error") => Some("transient"),
-                    Some("transcode_error") => Some("lossy_or_capability"),
-                    _ => {
-                        // Provider-native codes: substring match
-                        let lower = e.code.as_deref().unwrap_or("").to_lowercase();
-                        if lower.contains("rate_limit") || lower == "429" {
-                            Some("rate_limited")
-                        } else if lower.contains("auth") {
-                            Some("upstream_auth")
-                        } else {
-                            // overloaded, service_unavailable, and
-                            // everything else → transient
-                            Some("transient")
-                        }
-                    }
-                }
-                .map(String::from)
+            a.upstream_error.as_ref().map(|e| {
+                e.class.to_request_class().as_str().to_string()
             })
         });
         Some((
@@ -739,17 +720,24 @@ pub(super) fn drive_upstream_stream(
                                                 // the capture guard /
                                                 // telemetry can mark the
                                                 // request as failed.
-                                                if let tiygate_core::ir::StreamPart::Error { message, code } = part {
+                                                if let tiygate_core::ir::StreamPart::Error {
+                                                    message,
+                                                    class,
+                                                    upstream_code,
+                                                } = part
+                                                {
                                                     if let Ok(mut a) = accum.lock() {
-                                                        a.set_upstream_error(message, code.as_deref());
+                                                        a.set_upstream_error(message, upstream_code.as_deref());
                                                     }
+                                                    // Use the class from the decoded error frame
+                                                    let _ = class; // class is used via encode_part
                                                 }
                                                 match tc.encoder.encode_part(part) {
                                                     Ok(b) => out.extend_from_slice(&b),
                                                     Err(e) => {
                                                         let ef = tc.encoder.encode_error(
                                                             &format!("transcode encode error: {e}"),
-                                                            Some("transcode_error"),
+                                                            tiygate_core::ErrorClass::LossyOrCapability, None,
                                                         );
                                                         out.extend_from_slice(&ef);
                                                     }
@@ -759,7 +747,7 @@ pub(super) fn drive_upstream_stream(
                                         Err(e) => {
                                             let ef = tc.encoder.encode_error(
                                                 &format!("transcode decode error: {e}"),
-                                                Some("transcode_error"),
+                                                tiygate_core::ErrorClass::LossyOrCapability, None,
                                             );
                                             out.extend_from_slice(&ef);
                                         }
@@ -846,7 +834,7 @@ pub(super) fn drive_upstream_stream(
                             if let Some(tc) = transcode.as_mut() {
                                 let ef = tc.encoder.encode_error(
                                     "upstream stream truncated by gateway",
-                                    Some("upstream_error"),
+                                    tiygate_core::ErrorClass::Transient, None,
                                 );
                                 if !ef.is_empty() {
                                     capture_guard.append_client(&ef);
@@ -1024,7 +1012,7 @@ pub(super) fn drive_upstream_stream(
                     if let Some(tc) = transcode.as_mut() {
                         let ef = tc.encoder.encode_error(
                             "upstream stream idle timeout",
-                            Some("upstream_timeout"),
+                            tiygate_core::ErrorClass::DeadlineExceeded, None,
                         );
                         if !ef.is_empty() {
                             capture_guard.append_client(&ef);
@@ -1060,7 +1048,7 @@ pub(super) fn drive_upstream_stream(
                     if let Some(tc) = transcode.as_mut() {
                         let ef = tc.encoder.encode_error(
                             "upstream stream exceeded gateway total budget",
-                            Some("upstream_timeout"),
+                            tiygate_core::ErrorClass::DeadlineExceeded, None,
                         );
                         if !ef.is_empty() {
                             capture_guard.append_client(&ef);

--- a/crates/server/src/telemetry.rs
+++ b/crates/server/src/telemetry.rs
@@ -322,6 +322,7 @@ mod tests {
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         }
     }
 }

--- a/crates/store/src/log_sink/oltp.rs
+++ b/crates/store/src/log_sink/oltp.rs
@@ -414,8 +414,12 @@ impl EventSink for OltpSink {
         // `update_request_truncation` so it is order-independent
         // with `write_request_event`.
         if let Some(error_source) = &capture.upstream_error {
+            let error_class = capture
+                .upstream_error_class
+                .as_deref()
+                .unwrap_or("transient");
             if let Err(e) = self
-                .update_request_failure(&capture.request_id, "transient", error_source)
+                .update_request_failure(&capture.request_id, error_class, error_source)
                 .await
             {
                 warn!(
@@ -3520,6 +3524,7 @@ mod tests {
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -3579,6 +3584,7 @@ mod tests {
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4088,6 +4094,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+                    upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4143,6 +4150,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4193,6 +4201,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4236,6 +4245,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: None,
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
         let count: i64 =
@@ -4288,6 +4298,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: Some("idle".to_string()),
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4334,6 +4345,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: Some("upstream_error".to_string()),
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4388,6 +4400,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             truncation_reason: Some("client_disconnect".to_string()),
             stream_duration_ms: None,
             upstream_error: None,
+            upstream_error_class: None,
         };
         sink.write_capture(&capture).await.expect("write capture");
 
@@ -4441,6 +4454,7 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
             upstream_error: Some(
                 "Service unavailable (service_unavailable_error)".to_string(),
             ),
+            upstream_error_class: Some("transient".to_string()),
         };
         sink.write_capture(&capture).await.expect("write capture");
 

--- a/docs/error-code-matrix.md
+++ b/docs/error-code-matrix.md
@@ -1,0 +1,111 @@
+# Error Code Matrix
+
+This document describes how TiyGate normalizes upstream and gateway-internal errors into protocol-native error responses.
+
+## Design Principle
+
+**Clients see the same error format they would receive when talking directly to the upstream provider.** The gateway is transparent — standard OpenAI/Anthropic/Gemini SDKs see the expected `error.type`/`error.status` and HTTP status code without needing any gateway-specific knowledge.
+
+## ErrorClass Enum
+
+`ErrorClass` (`crates/core/src/routing/mod.rs`) is the canonical intermediate representation between opaque upstream error codes and protocol-native `error.type`/`error.status` fields.
+
+| Variant | Retry? | HTTP Status | Description |
+|---|---|---|---|
+| `Transient` | Yes | 502 | Upstream 5xx, timeout, transport error |
+| `RateLimited` | Yes (backoff) | 429 | Upstream rate limit |
+| `Auth` | Transfer | 401 | Upstream authentication error |
+| `BadRequest` | No | 400 | Malformed request rejected by upstream |
+| `LossyOrCapability` | No | 400 | Protocol conversion lossy or unsupported |
+| `ModelNotFound` | No | 404 | No route found for virtual model |
+| `DeadlineExceeded` | Yes | 504 | Gateway deadline exceeded |
+| `UpstreamExhausted` | No | 502 | All upstream targets exhausted |
+| `AuthMissing` | No | 401 | Inbound API key missing |
+| `AuthInvalid` | No | 401 | Inbound API key invalid |
+| `AuthDisabled` | No | 403 | Inbound API key disabled |
+| `Overloaded` | Yes (backoff) | 503 | Gateway overloaded |
+
+## ErrorClass → Protocol-Native Type Mapping
+
+### OpenAI (ChatCompletions / Responses / Embeddings / Images)
+
+| ErrorClass | `error.type` | HTTP Status |
+|---|---|---|
+| Transient | `server_error` | 502 |
+| RateLimited | `rate_limit_error` | 429 |
+| Auth | `authentication_error` | 401 |
+| BadRequest | `invalid_request_error` | 400 |
+| LossyOrCapability | `invalid_request_error` | 400 |
+| ModelNotFound | `not_found_error` | 404 |
+| DeadlineExceeded | `server_error` | 504 |
+| UpstreamExhausted | `server_error` | 502 |
+| AuthMissing | `authentication_error` | 401 |
+| AuthInvalid | `authentication_error` | 401 |
+| AuthDisabled | `permission_error` | 403 |
+| Overloaded | `overloaded_error` | 503 |
+
+JSON body format: `{"error":{"message":"...","type":"...","param":null,"code":"..."}}`
+
+### Anthropic Messages
+
+| ErrorClass | `error.type` | HTTP Status |
+|---|---|---|
+| Transient | `api_error` | 500 |
+| RateLimited | `rate_limit_error` | 429 |
+| Auth | `authentication_error` | 401 |
+| BadRequest | `invalid_request_error` | 400 |
+| LossyOrCapability | `invalid_request_error` | 400 |
+| ModelNotFound | `not_found_error` | 404 |
+| DeadlineExceeded | `timeout_error` | 504 |
+| UpstreamExhausted | `overloaded_error` | 529 |
+| AuthMissing | `authentication_error` | 401 |
+| AuthInvalid | `authentication_error` | 401 |
+| AuthDisabled | `permission_error` | 403 |
+| Overloaded | `overloaded_error` | 529 |
+
+JSON body format: `{"type":"error","error":{"type":"...","message":"..."}}`
+
+### Google Gemini
+
+| ErrorClass | `error.status` | HTTP Status |
+|---|---|---|
+| Transient | `INTERNAL` | 500 |
+| RateLimited | `RESOURCE_EXHAUSTED` | 429 |
+| Auth | `UNAUTHENTICATED` | 401 |
+| BadRequest | `INVALID_ARGUMENT` | 400 |
+| LossyOrCapability | `FAILED_PRECONDITION` | 400 |
+| ModelNotFound | `NOT_FOUND` | 404 |
+| DeadlineExceeded | `DEADLINE_EXCEEDED` | 504 |
+| UpstreamExhausted | `UNAVAILABLE` | 503 |
+| AuthMissing | `UNAUTHENTICATED` | 401 |
+| AuthInvalid | `UNAUTHENTICATED` | 401 |
+| AuthDisabled | `PERMISSION_DENIED` | 403 |
+| Overloaded | `UNAVAILABLE` | 503 |
+
+JSON body format: `{"error":{"code":<http_status>,"message":"...","status":"...","details":[]}}`
+
+## Upstream Error Normalization
+
+`classify_upstream_error(upstream_status: Option<u16>, upstream_code: Option<&str>) -> ErrorClass` in `crates/core/src/routing/mod.rs` is the single source of truth for upstream error normalization.
+
+Classification priority:
+1. **HTTP status exact match**: 429→RateLimited, 401/403→Auth, 400/422→BadRequest, 404→ModelNotFound, 504→DeadlineExceeded, ≥500→Transient
+2. **Error code substring match** (case-insensitive): `rate_limit`/`quota`/`429`/`resource_exhausted`→RateLimited, `auth`/`invalid_api_key`/`permission`/`unauthenticated`→Auth, `bad_request`/`invalid_argument`/`invalid_request`→BadRequest, `overloaded`/`service_unavailable`/`529`/`503`/`unavailable`→Overloaded, `timeout`/`deadline`→DeadlineExceeded, `not_found`/`model_not_found`/`404`→ModelNotFound
+3. **Default**: Transient
+
+## Architecture
+
+```
+Upstream error → classify_upstream_error() → ErrorClass → protocol mapping → native error.type/status
+Gateway error  → directly set ErrorClass    → ErrorClass → protocol mapping → native error.type/status
+```
+
+- `AppError` carries `error_class: ErrorClass` and `protocol_suite: Option<ProtocolSuite>`.
+- `AppError::into_response()` calls `encode_error_body_for_suite()` to generate the protocol-native body.
+- `StreamPart::Error` carries `class: ErrorClass` and `upstream_code: Option<String>`.
+- `StreamEncoder::encode_error()` and `EndpointCodec::encode_error_body()` use the ErrorClass → type/status mapping.
+- `UpstreamStreamError` carries `class: ErrorClass` for telemetry classification.
+
+## Related Documentation
+
+- [Protocol Capability Matrix](protocol-capability-matrix.md) — documents lossy protocol translation behavior.


### PR DESCRIPTION
## Summary
- Make structured `error.code` flow end-to-end from upstream/provider through gateway to client JSON responses (previously discarded by all 5 protocol encoders)
- Add `classify_structured()` for HTTP status + code based error classification, replacing fragile substring matching in fallback decisions
- Populate `request_logs.error_class` with accurate canonical classes instead of hardcoded `"transient"`

## Changes
- **Protocol encoders** (ChatCompletions, Messages, Responses, Gemini, Embeddings): `encode_error` and `encode_part(Error)` now serialize `code` into client JSON. Gemini uses `code` for `error.status` instead of hardcoding `"INTERNAL"`.
- **AppError**: new `upstream_error_code` field + `with_code()` builder + `IntoResponse` emits `error.code`.
- **Executors**: `check_nonstream_error_body` and all non-2xx JSON-parsed paths extract `error.code`/`error.type` from upstream.
- **Gateway self-errors**: carry semantic codes (`model_not_found`, `rate_limited`, `gateway_overloaded`, `deadline_exceeded`, `bad_request`, `upstream_exhausted`, `auth_missing`, `auth_invalid`, `auth_disabled`).
- **Routing**: new `classify_structured(upstream_status, upstream_code)` function; `fallback.rs` prefers it over substring matching.
- **Telemetry**: `ExchangeCapture` gains `upstream_error_class`; `streaming.rs::take_capture` maps error codes to `RequestErrorClass`; `oltp.rs` uses it instead of hardcoded `"transient"`.

## Test Plan
- [x] `cargo check --workspace --all-targets --all-features` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (except pre-existing flaky `test_health_registry_exponential_backoff`)
- [x] 4 protocol encoder tests assert `code` appears in output JSON
- [x] New `test_classify_structured` unit test covers 8 classification scenarios

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)