### PR TITLE
fix(webui): 🐛 keep JSON editor mounted and mark disabled routes

### DIFF
--- a/webui/src/components/ui/json-editor.tsx
+++ b/webui/src/components/ui/json-editor.tsx
@@ -122,7 +122,11 @@ export function JsonEditor({
       view.destroy();
       viewRef.current = null;
     };
-  }, [extensions, value]);
+  // Re-mount only when extensions change; `value` is intentionally excluded
+  // so that keystrokes (which update `value`) do not destroy & recreate the
+  // EditorView. External value updates are synced by the effect below.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [extensions]);
 
   useEffect(() => {
     const view = viewRef.current;

--- a/webui/src/pages/Routes.tsx
+++ b/webui/src/pages/Routes.tsx
@@ -785,7 +785,10 @@ export default function RoutesPage() {
                     >
                       <div className="flex items-center gap-1.5">
                         <span
-                          className="truncate font-medium text-text"
+                          className={cn(
+                            "truncate font-medium",
+                            r.enabled ? "text-text" : "text-text-subtle line-through",
+                          )}
                           title={r.virtual_model}
                         >
                           {r.virtual_model}


### PR DESCRIPTION
## Summary
- Fix JSON editor remounting on every keystroke by excluding `value` from the remount effect deps; external value updates are still synced by a separate effect.
- Style: render disabled routes with a struck-through, subtle label in the routes list for clearer visual state.

## Test Plan
- [ ] Type in a JSON editor field and confirm the EditorView is not recreated on each keystroke (no focus loss / flicker).
- [ ] Confirm external value updates (e.g. loaded config) still populate the editor.
- [ ] Verify disabled routes display with a strikethrough label.

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
