### PR TITLE
fix: 🐛 preserve Codex OAuth metadata across provider requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,6 +5901,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ backoff = "0.4"
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
+base64 = "0.22"
 twox-hash = { version = "2", default-features = false, features = ["xxhash64"] }
 
 # Rate limiting

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -95,6 +95,7 @@ async-trait.workspace = true
 clap.workspace = true
 sha2.workspace = true
 hex.workspace = true
+base64.workspace = true
 twox-hash.workspace = true
 dashmap.workspace = true
 sqlx.workspace = true

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -86,16 +86,34 @@ fn uses_anthropic_oauth_egress_profile(
 /// The profile is selected by the routing target, not by the ingress codec.
 /// This keeps Anthropic/Chat/Gemini ingress paths consistent when they route
 /// to the same Codex OAuth target. The returned tuple is
-/// `(profile_enabled, websocket_transport, body_changed)`.
+/// `(profile_enabled, websocket_transport, body_changed, session_key)`.
 fn prepare_codex_egress_body(
     target: &tiygate_core::RoutingTarget,
     egress_protocol: &tiygate_core::ProtocolEndpoint,
+    ingress_protocol: &tiygate_core::ProtocolEndpoint,
+    ir_request: &IrRequest,
+    client_headers: &http::HeaderMap,
     body: &mut Value,
-) -> (bool, bool, bool) {
+) -> Result<(bool, bool, bool, Option<String>), AppError> {
     let profile_enabled = codex_oauth::is_enabled(target, egress_protocol.suite);
     let websocket = profile_enabled && codex_oauth::uses_websocket(target);
-    let changed = profile_enabled && codex_oauth::prepare_body(body, websocket);
-    (profile_enabled, websocket, changed)
+    let mut changed = profile_enabled && codex_oauth::prepare_body(body, websocket);
+    let mut session_key = None;
+    if profile_enabled {
+        codex_oauth::validate_codex_tool_names(body)?;
+        changed |= codex_oauth::normalize_reasoning_and_ids(body, ir_request);
+        changed |= codex_oauth::normalize_parallel_tool_calls(body, client_headers);
+        session_key = codex_oauth::claude_prompt_cache_key(
+            ingress_protocol,
+            ir_request,
+            client_headers,
+            &target.model_id,
+        );
+        if let Some(key) = session_key.as_deref() {
+            changed |= codex_oauth::set_prompt_cache_key(body, key);
+        }
+    }
+    Ok((profile_enabled, websocket, changed, session_key))
 }
 
 fn egress_http_client(state: &AppState, anthropic_oauth_profile: bool) -> reqwest::Client {
@@ -529,8 +547,15 @@ pub(super) async fn execute_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
-    let (openai_codex_profile, codex_websocket, codex_body_changed) =
-        prepare_codex_egress_body(target, &egress_protocol, &mut upstream_body);
+    let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
+        prepare_codex_egress_body(
+            target,
+            &egress_protocol,
+            ingress_protocol,
+            ir_request,
+            client_headers,
+            &mut upstream_body,
+        )?;
     body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
@@ -553,7 +578,17 @@ pub(super) async fn execute_upstream(
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
     if openai_codex_profile {
-        codex_oauth::apply_headers(&mut upstream_headers);
+        codex_oauth::apply_request_headers(
+            &mut upstream_headers,
+            is_stream,
+            codex_websocket,
+            request_id,
+            codex_session_key.as_deref(),
+            target
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.account_id.as_deref()),
+        );
     }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
@@ -634,6 +669,17 @@ pub(super) async fn execute_upstream(
             Ok(response) => return Ok(response),
             Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
                 codex_oauth::prepare_body(&mut upstream_body, false);
+                codex_oauth::apply_request_headers(
+                    &mut upstream_headers,
+                    is_stream,
+                    false,
+                    request_id,
+                    codex_session_key.as_deref(),
+                    target
+                        .oauth
+                        .as_ref()
+                        .and_then(|oauth| oauth.account_id.as_deref()),
+                );
                 egress_body_capture = serde_json::to_string(&upstream_body).ok();
             }
             Err(error) => return Err(error),
@@ -1093,8 +1139,15 @@ pub(super) async fn execute_messages_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
-    let (openai_codex_profile, codex_websocket, codex_body_changed) =
-        prepare_codex_egress_body(target, &egress_protocol, &mut upstream_body);
+    let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
+        prepare_codex_egress_body(
+            target,
+            &egress_protocol,
+            ingress_protocol,
+            ir_request,
+            client_headers,
+            &mut upstream_body,
+        )?;
     body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
@@ -1117,7 +1170,17 @@ pub(super) async fn execute_messages_upstream(
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
     if openai_codex_profile {
-        codex_oauth::apply_headers(&mut upstream_headers);
+        codex_oauth::apply_request_headers(
+            &mut upstream_headers,
+            is_stream,
+            codex_websocket,
+            request_id,
+            codex_session_key.as_deref(),
+            target
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.account_id.as_deref()),
+        );
     }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
@@ -1184,6 +1247,17 @@ pub(super) async fn execute_messages_upstream(
             Ok(response) => return Ok(response),
             Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
                 codex_oauth::prepare_body(&mut upstream_body, false);
+                codex_oauth::apply_request_headers(
+                    &mut upstream_headers,
+                    is_stream,
+                    false,
+                    request_id,
+                    codex_session_key.as_deref(),
+                    target
+                        .oauth
+                        .as_ref()
+                        .and_then(|oauth| oauth.account_id.as_deref()),
+                );
                 egress_body_capture = serde_json::to_string(&upstream_body).ok();
             }
             Err(error) => return Err(error),
@@ -1903,11 +1977,16 @@ pub(super) async fn execute_responses_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
-    let openai_codex_profile = codex_oauth::is_enabled(target, egress_protocol.suite);
-    let codex_websocket = openai_codex_profile && codex_oauth::uses_websocket(target);
-    if openai_codex_profile {
-        body_mutated |= codex_oauth::prepare_body(&mut upstream_body, codex_websocket);
-    }
+    let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
+        prepare_codex_egress_body(
+            target,
+            &egress_protocol,
+            ingress_protocol,
+            ir_request,
+            client_headers,
+            &mut upstream_body,
+        )?;
+    body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
         body_mutated |= crate::anthropic_oauth::prepare_body(&mut upstream_body);
@@ -1920,7 +1999,17 @@ pub(super) async fn execute_responses_upstream(
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
     if openai_codex_profile {
-        codex_oauth::apply_headers(&mut upstream_headers);
+        codex_oauth::apply_request_headers(
+            &mut upstream_headers,
+            is_stream,
+            codex_websocket,
+            request_id,
+            codex_session_key.as_deref(),
+            target
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.account_id.as_deref()),
+        );
     }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
@@ -1986,6 +2075,17 @@ pub(super) async fn execute_responses_upstream(
             Ok(response) => return Ok(response),
             Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
                 codex_oauth::prepare_body(&mut upstream_body, false);
+                codex_oauth::apply_request_headers(
+                    &mut upstream_headers,
+                    is_stream,
+                    false,
+                    request_id,
+                    codex_session_key.as_deref(),
+                    target
+                        .oauth
+                        .as_ref()
+                        .and_then(|oauth| oauth.account_id.as_deref()),
+                );
                 egress_body_capture = serde_json::to_string(&upstream_body).ok();
             }
             Err(error) => return Err(error),
@@ -2709,8 +2809,15 @@ pub(super) async fn execute_gemini_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
-    let (openai_codex_profile, codex_websocket, codex_body_changed) =
-        prepare_codex_egress_body(target, &egress_protocol, &mut upstream_body);
+    let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
+        prepare_codex_egress_body(
+            target,
+            &egress_protocol,
+            ingress_protocol,
+            ir_request,
+            client_headers,
+            &mut upstream_body,
+        )?;
     body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
@@ -2724,7 +2831,17 @@ pub(super) async fn execute_gemini_upstream(
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
     if openai_codex_profile {
-        codex_oauth::apply_headers(&mut upstream_headers);
+        codex_oauth::apply_request_headers(
+            &mut upstream_headers,
+            is_stream,
+            codex_websocket,
+            request_id,
+            codex_session_key.as_deref(),
+            target
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.account_id.as_deref()),
+        );
     }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
@@ -2787,6 +2904,17 @@ pub(super) async fn execute_gemini_upstream(
             Ok(response) => return Ok(response),
             Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
                 codex_oauth::prepare_body(&mut upstream_body, false);
+                codex_oauth::apply_request_headers(
+                    &mut upstream_headers,
+                    is_stream,
+                    false,
+                    request_id,
+                    codex_session_key.as_deref(),
+                    target
+                        .oauth
+                        .as_ref()
+                        .and_then(|oauth| oauth.account_id.as_deref()),
+                );
                 egress_body_capture = serde_json::to_string(&upstream_body).ok();
             }
             Err(error) => return Err(error),
@@ -3993,8 +4121,8 @@ mod tests {
             http::header::USER_AGENT,
             http::HeaderValue::from_static("Codex Desktop/1 (Mac OS 26; arm64)"),
         );
-        codex_oauth::apply_headers(&mut headers);
-        assert!(headers.contains_key("session_id"));
+        codex_oauth::apply_request_headers(&mut headers, false, false, "", None, None);
+        assert!(headers.contains_key("session-id"));
     }
 
     #[test]

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -81,6 +81,23 @@ fn uses_anthropic_oauth_egress_profile(
     crate::anthropic_oauth::is_enabled(target, egress_protocol.suite)
 }
 
+/// Apply the provider-owned Codex Responses profile to an egress body.
+///
+/// The profile is selected by the routing target, not by the ingress codec.
+/// This keeps Anthropic/Chat/Gemini ingress paths consistent when they route
+/// to the same Codex OAuth target. The returned tuple is
+/// `(profile_enabled, websocket_transport, body_changed)`.
+fn prepare_codex_egress_body(
+    target: &tiygate_core::RoutingTarget,
+    egress_protocol: &tiygate_core::ProtocolEndpoint,
+    body: &mut Value,
+) -> (bool, bool, bool) {
+    let profile_enabled = codex_oauth::is_enabled(target, egress_protocol.suite);
+    let websocket = profile_enabled && codex_oauth::uses_websocket(target);
+    let changed = profile_enabled && codex_oauth::prepare_body(body, websocket);
+    (profile_enabled, websocket, changed)
+}
+
 fn egress_http_client(state: &AppState, anthropic_oauth_profile: bool) -> reqwest::Client {
     let tunables = state.tunables();
     if anthropic_oauth_profile {
@@ -353,6 +370,39 @@ fn map_nonstream_reqwest_error(error: reqwest::Error, context: &str) -> AppError
     }
 }
 
+/// Parse a completed non-streaming upstream body.
+///
+/// Codex HTTP transport always asks the subscription backend for an SSE
+/// response, even when the downstream request was non-streaming. Other
+/// upstreams retain the ordinary JSON contract. Non-success responses are
+/// parsed as JSON when possible so the caller can preserve the upstream error
+/// status and body instead of treating a FastAPI `detail` response as a local
+/// parse failure.
+fn parse_nonstream_upstream_body(
+    response_text: &str,
+    status: StatusCode,
+    codex_profile: bool,
+) -> Result<Value, AppError> {
+    if !status.is_success() {
+        return Ok(serde_json::from_str(response_text).unwrap_or_else(|_| {
+            json!({
+                "error": {
+                    "type": "upstream_error",
+                    "message": response_text,
+                }
+            })
+        }));
+    }
+
+    if codex_profile {
+        codex_oauth::parse_http_response(response_text)
+    } else {
+        serde_json::from_str(response_text).map_err(|error| {
+            AppError::new(StatusCode::BAD_GATEWAY, format!("Parse error: {error}"))
+        })
+    }
+}
+
 /// Check whether an HTTP 200 non-streaming response body is actually
 /// an error response (top-level `"error"` key). Some providers return
 /// HTTP 200 with `{"error": {...}}` instead of a proper non-2xx status
@@ -479,6 +529,9 @@ pub(super) async fn execute_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
+    let (openai_codex_profile, codex_websocket, codex_body_changed) =
+        prepare_codex_egress_body(target, &egress_protocol, &mut upstream_body);
+    body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
         body_mutated |= crate::anthropic_oauth::prepare_body(&mut upstream_body);
@@ -499,6 +552,9 @@ pub(super) async fn execute_upstream(
         &state.tunables().header_policy,
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    if openai_codex_profile {
+        codex_oauth::apply_headers(&mut upstream_headers);
+    }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
@@ -513,7 +569,7 @@ pub(super) async fn execute_upstream(
     // (see `finalize_egress` below) so the snapshot includes every
     // header reqwest adds at finalize time (content-type, content-length,
     // traceparent, auth). The body snapshot is taken here.
-    let egress_body_capture = if pass_through_verbatim {
+    let mut egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
     } else {
         serde_json::to_string(&upstream_body).ok()
@@ -541,6 +597,48 @@ pub(super) async fn execute_upstream(
             ),
         )
     })?;
+
+    // Codex WebSocket transport is provider-owned and independent of the
+    // ingress protocol. The bridge converts the Responses wire events back to
+    // the caller's codec, so Anthropic/Chat/Gemini clients can use it too.
+    if codex_websocket && egress_protocol.suite == tiygate_core::ProtocolSuite::OpenAiResponses {
+        let websocket_future = execute_codex_responses_websocket(
+            state,
+            codec,
+            ingress_protocol,
+            &egress_protocol,
+            ir_request,
+            target,
+            is_stream,
+            upstream_url.clone(),
+            upstream_body.clone(),
+            upstream_headers.clone(),
+            trace,
+            request_id,
+            is_same_protocol,
+        );
+        let websocket_result = if is_stream || nonstream_timeout_secs == 0 {
+            websocket_future.await
+        } else {
+            match tokio::time::timeout(
+                Duration::from_secs(nonstream_timeout_secs),
+                websocket_future,
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(nonstream_timeout_error()),
+            }
+        };
+        match websocket_result {
+            Ok(response) => return Ok(response),
+            Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
+                codex_oauth::prepare_body(&mut upstream_body, false);
+                egress_body_capture = serde_json::to_string(&upstream_body).ok();
+            }
+            Err(error) => return Err(error),
+        }
+    }
 
     if is_stream {
         // PassThrough: forward raw body bytes verbatim (no re-serialize).
@@ -725,6 +823,9 @@ pub(super) async fn execute_upstream(
             ),
             trace,
         );
+        if openai_codex_profile {
+            nonstream_req = nonstream_req.header(http::header::ACCEPT, "text/event-stream");
+        }
         if pass_through_verbatim {
             if let Some(raw) = raw_passthrough_body {
                 nonstream_req = nonstream_req
@@ -754,10 +855,12 @@ pub(super) async fn execute_upstream(
         // the body, for the request-log detail view.
         let upstream_resp_headers_capture = reqwest_headers_to_vec(response.headers());
         let upstream_status_capture = status.as_u16();
-        let response_body: Value = response
-            .json()
+        let response_text = response
+            .text()
             .await
-            .map_err(|error| map_nonstream_reqwest_error(error, "Parse error"))?;
+            .map_err(|error| map_nonstream_reqwest_error(error, "Read error"))?;
+        let response_body =
+            parse_nonstream_upstream_body(&response_text, status, openai_codex_profile)?;
 
         if !status.is_success() {
             // Capture the failed exchange (upstream error body) so the
@@ -843,7 +946,11 @@ pub(super) async fn execute_upstream(
 
         // Keep a copy of the raw upstream body for the capture before
         // any cross-protocol re-encoding.
-        let upstream_resp_body_capture = serde_json::to_string(&response_body).ok();
+        let upstream_resp_body_capture = if openai_codex_profile {
+            Some(response_text)
+        } else {
+            serde_json::to_string(&response_body).ok()
+        };
 
         // Cross-protocol re-encoding
         let mut response_json = if is_same_protocol {
@@ -986,6 +1093,9 @@ pub(super) async fn execute_messages_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
+    let (openai_codex_profile, codex_websocket, codex_body_changed) =
+        prepare_codex_egress_body(target, &egress_protocol, &mut upstream_body);
+    body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
         body_mutated |= crate::anthropic_oauth::prepare_body(&mut upstream_body);
@@ -1006,12 +1116,15 @@ pub(super) async fn execute_messages_upstream(
         &state.tunables().header_policy,
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    if openai_codex_profile {
+        codex_oauth::apply_headers(&mut upstream_headers);
+    }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
 
     // Capture egress request (headers + body) for the detail view.
-    let egress_body_capture = if pass_through_verbatim {
+    let mut egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
     } else {
         serde_json::to_string(&upstream_body).ok()
@@ -1037,6 +1150,45 @@ pub(super) async fn execute_messages_upstream(
             ),
         )
     })?;
+
+    if codex_websocket && egress_protocol.suite == tiygate_core::ProtocolSuite::OpenAiResponses {
+        let websocket_future = execute_codex_responses_websocket(
+            state,
+            codec,
+            ingress_protocol,
+            &egress_protocol,
+            ir_request,
+            target,
+            is_stream,
+            upstream_url.clone(),
+            upstream_body.clone(),
+            upstream_headers.clone(),
+            trace,
+            request_id,
+            is_same_protocol,
+        );
+        let websocket_result = if is_stream || nonstream_timeout_secs == 0 {
+            websocket_future.await
+        } else {
+            match tokio::time::timeout(
+                Duration::from_secs(nonstream_timeout_secs),
+                websocket_future,
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(nonstream_timeout_error()),
+            }
+        };
+        match websocket_result {
+            Ok(response) => return Ok(response),
+            Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
+                codex_oauth::prepare_body(&mut upstream_body, false);
+                egress_body_capture = serde_json::to_string(&upstream_body).ok();
+            }
+            Err(error) => return Err(error),
+        }
+    }
 
     if is_stream {
         // No `.timeout()` on the streaming branch: reqwest's request
@@ -1189,6 +1341,9 @@ pub(super) async fn execute_messages_upstream(
             ),
             trace,
         );
+        if openai_codex_profile {
+            nonstream_req = nonstream_req.header(http::header::ACCEPT, "text/event-stream");
+        }
         if pass_through_verbatim {
             if let Some(raw) = raw_passthrough_body {
                 nonstream_req = nonstream_req
@@ -1216,10 +1371,12 @@ pub(super) async fn execute_messages_upstream(
         let status = response.status();
         let upstream_resp_headers_capture = reqwest_headers_to_vec(response.headers());
         let upstream_status_capture = status.as_u16();
-        let response_body: Value = response
-            .json()
+        let response_text = response
+            .text()
             .await
-            .map_err(|error| map_nonstream_reqwest_error(error, "Parse error"))?;
+            .map_err(|error| map_nonstream_reqwest_error(error, "Read error"))?;
+        let response_body =
+            parse_nonstream_upstream_body(&response_text, status, openai_codex_profile)?;
 
         if !status.is_success() {
             spawn_capture(
@@ -1300,7 +1457,11 @@ pub(super) async fn execute_messages_upstream(
             return Err(app_err);
         }
 
-        let upstream_resp_body_capture = serde_json::to_string(&response_body).ok();
+        let upstream_resp_body_capture = if openai_codex_profile {
+            Some(response_text)
+        } else {
+            serde_json::to_string(&response_body).ok()
+        };
 
         // Cross-protocol re-encoding: when the upstream spoke a different
         // protocol (e.g. OpenAI chat-completions) than the client's ingress
@@ -2182,7 +2343,7 @@ pub(super) async fn execute_responses_upstream(
 #[allow(clippy::too_many_arguments)]
 async fn execute_codex_responses_websocket(
     state: &AppState,
-    codec: &ResponsesCodec,
+    ingress_codec: &dyn EndpointCodec,
     ingress_protocol: &tiygate_core::ProtocolEndpoint,
     egress_protocol: &tiygate_core::ProtocolEndpoint,
     ir_request: &IrRequest,
@@ -2332,8 +2493,8 @@ async fn execute_codex_responses_websocket(
 
     if is_stream {
         let accum = std::sync::Arc::new(std::sync::Mutex::new(UsageAccumulator::new()));
-        let mut end_enc = codec.stream_encoder();
-        let mut err_enc = codec.stream_encoder();
+        let mut end_enc = ingress_codec.stream_encoder();
+        let mut err_enc = ingress_codec.stream_encoder();
         let end_marker = end_enc.encode_done();
         let error_marker = err_enc.encode_error(
             "upstream stream truncated by gateway",
@@ -2423,12 +2584,14 @@ async fn execute_codex_responses_websocket(
                     format!("Decode response error: {error}"),
                 )
             })?;
-        codec.encode_response(&ir_response).map_err(|error| {
-            AppError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Encode response error: {error}"),
-            )
-        })?
+        ingress_codec
+            .encode_response(&ir_response)
+            .map_err(|error| {
+                AppError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Encode response error: {error}"),
+                )
+            })?
     };
     ResponseModelOverride::new(ingress_protocol.suite, &ir_request.model)
         .apply_json(&mut response_body);
@@ -2546,6 +2709,9 @@ pub(super) async fn execute_gemini_upstream(
         &egress_protocol.suite,
         &target.model_id,
     );
+    let (openai_codex_profile, codex_websocket, codex_body_changed) =
+        prepare_codex_egress_body(target, &egress_protocol, &mut upstream_body);
+    body_mutated |= codex_body_changed;
     let anthropic_oauth_profile = uses_anthropic_oauth_egress_profile(target, &egress_protocol);
     if anthropic_oauth_profile {
         body_mutated |= crate::anthropic_oauth::prepare_body(&mut upstream_body);
@@ -2557,11 +2723,14 @@ pub(super) async fn execute_gemini_upstream(
         &state.tunables().header_policy,
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    if openai_codex_profile {
+        codex_oauth::apply_headers(&mut upstream_headers);
+    }
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
 
-    let egress_body_capture = if pass_through_verbatim {
+    let mut egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
     } else {
         serde_json::to_string(&upstream_body).ok()
@@ -2584,6 +2753,45 @@ pub(super) async fn execute_gemini_upstream(
         )
     })?;
     let nonstream_timeout_secs = state.tunables().upstream_nonstream_timeout_secs;
+
+    if codex_websocket && egress_protocol.suite == tiygate_core::ProtocolSuite::OpenAiResponses {
+        let websocket_future = execute_codex_responses_websocket(
+            state,
+            codec,
+            ingress_protocol,
+            &egress_protocol,
+            ir_request,
+            target,
+            is_stream,
+            upstream_url.clone(),
+            upstream_body.clone(),
+            upstream_headers.clone(),
+            trace,
+            request_id,
+            is_same_protocol,
+        );
+        let websocket_result = if is_stream || nonstream_timeout_secs == 0 {
+            websocket_future.await
+        } else {
+            match tokio::time::timeout(
+                Duration::from_secs(nonstream_timeout_secs),
+                websocket_future,
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(nonstream_timeout_error()),
+            }
+        };
+        match websocket_result {
+            Ok(response) => return Ok(response),
+            Err(error) if error.http_status() == StatusCode::UPGRADE_REQUIRED => {
+                codex_oauth::prepare_body(&mut upstream_body, false);
+                egress_body_capture = serde_json::to_string(&upstream_body).ok();
+            }
+            Err(error) => return Err(error),
+        }
+    }
 
     if is_stream {
         let mut stream_req = crate::ingress::observability::inject_trace(
@@ -2728,6 +2936,9 @@ pub(super) async fn execute_gemini_upstream(
         ),
         trace,
     );
+    if openai_codex_profile {
+        nonstream_req = nonstream_req.header(http::header::ACCEPT, "text/event-stream");
+    }
     if pass_through_verbatim {
         if let Some(raw) = raw_passthrough_body {
             nonstream_req = nonstream_req
@@ -2753,10 +2964,12 @@ pub(super) async fn execute_gemini_upstream(
         extract_rate_limit_headers(response.headers());
     let upstream_resp_headers_capture = reqwest_headers_to_vec(response.headers());
     let upstream_status_capture = status.as_u16();
-    let response_body: Value = response
-        .json()
+    let response_text = response
+        .text()
         .await
-        .map_err(|error| map_nonstream_reqwest_error(error, "Parse error"))?;
+        .map_err(|error| map_nonstream_reqwest_error(error, "Read error"))?;
+    let response_body =
+        parse_nonstream_upstream_body(&response_text, status, openai_codex_profile)?;
     if !status.is_success() {
         spawn_capture(
             state,
@@ -2831,7 +3044,11 @@ pub(super) async fn execute_gemini_upstream(
         return Err(app_err);
     }
 
-    let upstream_resp_body_capture = serde_json::to_string(&response_body).ok();
+    let upstream_resp_body_capture = if openai_codex_profile {
+        Some(response_text)
+    } else {
+        serde_json::to_string(&response_body).ok()
+    };
     let mut response_body = if is_same_protocol {
         response_body
     } else {

--- a/crates/server/src/openai_codex_oauth.rs
+++ b/crates/server/src/openai_codex_oauth.rs
@@ -60,6 +60,7 @@ pub(crate) fn prepare_body(body: &mut Value, websocket: bool) -> bool {
     // `{"detail":"Unsupported parameter: max_output_tokens"}` when it is
     // present — strip it here so relayed clients cannot break the request.
     for field in [
+        "metadata",
         "prompt_cache_retention",
         "safety_identifier",
         "max_output_tokens",
@@ -282,13 +283,14 @@ mod tests {
     }
 
     #[test]
-    fn prepare_body_strips_max_output_tokens_on_both_transports() {
+    fn prepare_body_strips_codex_unsupported_fields_on_both_transports() {
         for websocket in [false, true] {
             let mut body = json!({
                 "model": "gpt-5.6",
                 "stream": false,
                 "instructions": null,
                 "input": "hi",
+                "metadata": {"user_id": "user-123"},
                 "max_output_tokens": 4096,
                 "prompt_cache_retention": "24h",
                 "safety_identifier": "user",
@@ -301,6 +303,7 @@ mod tests {
             assert_eq!(body["store"], false);
             assert_eq!(body["model"], "gpt-5.6");
             assert_eq!(body["input"], "hi");
+            assert!(body.get("metadata").is_none());
             assert!(
                 body.get("max_output_tokens").is_none(),
                 "ChatGPT Codex backend rejects max_output_tokens (websocket={websocket})"

--- a/crates/server/src/openai_codex_oauth.rs
+++ b/crates/server/src/openai_codex_oauth.rs
@@ -4,16 +4,22 @@
 //! Responses request normalization, headers, HTTP response parsing, and
 //! WebSocket negotiation without creating a separate HTTP connection pool.
 
-use axum::http::StatusCode;
+use std::collections::HashMap;
+
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use tiygate_core::provider::oauth::{OAuthEgressProfile, UpstreamTransport};
-use tiygate_core::{ProtocolSuite, RoutingTarget};
+use tiygate_core::{Content, IrRequest, ProtocolEndpoint, ProtocolSuite, RoutingTarget};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
 use crate::ingress::AppError;
 
 /// Required by the Codex Responses WebSocket endpoint.
 pub(crate) const RESPONSES_WEBSOCKET_BETA: &str = "responses_websockets=2026-02-06";
+
+const CODEX_TOOL_NAME_MAX_BYTES: usize = 64;
 
 /// True when the routed request uses the OpenAI Codex OAuth Responses profile.
 pub(crate) fn is_enabled(target: &RoutingTarget, egress_suite: ProtocolSuite) -> bool {
@@ -34,61 +40,554 @@ pub(crate) fn uses_websocket(target: &RoutingTarget) -> bool {
 
 /// Normalize an OpenAI Responses body for the Codex OAuth contract.
 pub(crate) fn prepare_body(body: &mut Value, websocket: bool) -> bool {
-    let Some(object) = body.as_object_mut() else {
+    let mut changed = false;
+    {
+        let Some(object) = body.as_object_mut() else {
+            return false;
+        };
+        if object.get("stream").and_then(Value::as_bool) != Some(true) {
+            object.insert("stream".to_string(), json!(true));
+            changed = true;
+        }
+        if object.get("instructions").is_none_or(Value::is_null) {
+            object.insert("instructions".to_string(), json!(""));
+            changed = true;
+        }
+        // The ChatGPT subscription backend requires an explicit `store: false`
+        // request. This is specific to the Codex OAuth egress profile; the
+        // public OpenAI Responses API has different storage semantics.
+        if object.get("store").and_then(Value::as_bool) != Some(false) {
+            object.insert("store".to_string(), json!(false));
+            changed = true;
+        }
+        // The ChatGPT subscription backend (`/backend-api/codex/responses`,
+        // FastAPI) rejects Responses fields it does not model. The native Codex
+        // `ResponsesApiRequest` has no generic sampling/output fields such as
+        // `temperature`, `top_p`, `stop`, or `max_output_tokens`; strip them here
+        // so relayed clients cannot break the request.
+        for field in [
+            "metadata",
+            "prompt_cache_retention",
+            "safety_identifier",
+            "max_output_tokens",
+            "max_completion_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "user",
+            "truncation",
+            "prompt_cache_options",
+            "context_management",
+            "generate",
+        ] {
+            changed |= object.remove(field).is_some();
+        }
+        let include = json!(["reasoning.encrypted_content"]);
+        if object.get("include") != Some(&include) {
+            object.insert("include".to_string(), include);
+            changed = true;
+        }
+        if object.get("parallel_tool_calls").and_then(Value::as_bool) != Some(true) {
+            object.insert("parallel_tool_calls".to_string(), json!(true));
+            changed = true;
+        }
+        if !websocket {
+            for field in ["previous_response_id", "stream_options"] {
+                changed |= object.remove(field).is_some();
+            }
+        }
+    }
+    changed |= normalize_codex_input_shape(body);
+    changed |= normalize_codex_system_roles(body);
+    changed |= normalize_codex_service_tier(body);
+    changed |= strip_prompt_cache_breakpoints(body);
+    changed |= normalize_codex_input_ids(body);
+    changed
+}
+
+/// Codex expects Responses input strings in the message-array form.
+fn normalize_codex_input_shape(body: &mut Value) -> bool {
+    let Some(text) = body
+        .get("input")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return false;
+    };
+    body["input"] = json!([{
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": text}]
+    }]);
+    true
+}
+
+/// Codex does not accept `system` roles inside the Responses input array.
+fn normalize_codex_system_roles(body: &mut Value) -> bool {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
         return false;
     };
     let mut changed = false;
-    if object.get("stream").and_then(Value::as_bool) != Some(true) {
-        object.insert("stream".to_string(), json!(true));
-        changed = true;
-    }
-    if object.get("instructions").is_none_or(Value::is_null) {
-        object.insert("instructions".to_string(), json!(""));
-        changed = true;
-    }
-    // The ChatGPT subscription backend requires an explicit `store: false`
-    // request. This is specific to the Codex OAuth egress profile; the
-    // public OpenAI Responses API has different storage semantics.
-    if object.get("store").and_then(Value::as_bool) != Some(false) {
-        object.insert("store".to_string(), json!(false));
-        changed = true;
-    }
-    // The ChatGPT subscription backend (`/backend-api/codex/responses`,
-    // FastAPI) rejects Responses fields it does not model. The native Codex
-    // CLI never sends `max_output_tokens` (its ResponsesApiRequest has no
-    // such field), and the backend answers 400
-    // `{"detail":"Unsupported parameter: max_output_tokens"}` when it is
-    // present — strip it here so relayed clients cannot break the request.
-    for field in [
-        "metadata",
-        "prompt_cache_retention",
-        "safety_identifier",
-        "max_output_tokens",
-    ] {
-        changed |= object.remove(field).is_some();
-    }
-    if !websocket {
-        for field in ["previous_response_id", "stream_options"] {
-            changed |= object.remove(field).is_some();
+    for item in input {
+        if item.get("role").and_then(Value::as_str) == Some("system") {
+            item["role"] = json!("developer");
+            changed = true;
         }
     }
     changed
 }
 
-/// Apply Codex-owned request headers after credential injection.
-pub(crate) fn apply_headers(headers: &mut http::HeaderMap) {
-    let has_session = ["session_id", "session-id"]
-        .iter()
-        .any(|name| headers.contains_key(*name));
-    let desktop_user_agent = headers
-        .get(http::header::USER_AGENT)
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.contains("Mac OS"));
-    if desktop_user_agent && !has_session {
-        if let Ok(value) = http::HeaderValue::from_str(&uuid::Uuid::now_v7().to_string()) {
-            headers.insert(http::HeaderName::from_static("session_id"), value);
+/// Codex currently supports only the priority service tier.
+fn normalize_codex_service_tier(body: &mut Value) -> bool {
+    if body
+        .get("service_tier")
+        .is_some_and(|value| value.as_str() != Some("priority"))
+    {
+        return body
+            .as_object_mut()
+            .is_some_and(|object| object.remove("service_tier").is_some());
+    }
+    false
+}
+
+/// Reject tool names that Codex cannot accept rather than silently changing
+/// them and losing the mapping needed to address the original client tool.
+pub(crate) fn validate_codex_tool_names(body: &Value) -> Result<(), AppError> {
+    if let Some(tools) = body.get("tools").and_then(Value::as_array) {
+        for (index, tool) in tools.iter().enumerate() {
+            validate_codex_tool_name(tool.get("name"), &format!("tools[{index}].name"))?;
+            validate_codex_tool_name(
+                tool.pointer("/function/name"),
+                &format!("tools[{index}].function.name"),
+            )?;
         }
     }
+    if let Some(input) = body.get("input").and_then(Value::as_array) {
+        for (index, item) in input.iter().enumerate() {
+            validate_codex_tool_name(item.get("name"), &format!("input[{index}].name"))?;
+        }
+    }
+    if let Some(choice) = body.get("tool_choice") {
+        validate_codex_tool_name(choice.get("name"), "tool_choice.name")?;
+        validate_codex_tool_name(
+            choice.pointer("/function/name"),
+            "tool_choice.function.name",
+        )?;
+        if let Some(tools) = choice.get("tools").and_then(Value::as_array) {
+            for (index, tool) in tools.iter().enumerate() {
+                validate_codex_tool_name(
+                    tool.get("name"),
+                    &format!("tool_choice.tools[{index}].name"),
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_codex_tool_name(value: Option<&Value>, path: &str) -> Result<(), AppError> {
+    let Some(name) = value.and_then(Value::as_str) else {
+        return Ok(());
+    };
+    if name.len() <= CODEX_TOOL_NAME_MAX_BYTES {
+        return Ok(());
+    }
+    Err(AppError::new(
+        StatusCode::BAD_REQUEST,
+        format!("Codex tool name at {path} exceeds {CODEX_TOOL_NAME_MAX_BYTES}-byte limit"),
+    )
+    .with_class(tiygate_core::ErrorClass::LossyOrCapability)
+    .with_upstream_code("unsupported_tool_name"))
+}
+
+/// Apply the Codex-specific reasoning and identity rules after IR encoding.
+///
+/// Anthropic signatures are not interchangeable with Codex encrypted content.
+/// Only a locally valid GPT-shaped encrypted signature is replayed; invalid or
+/// foreign reasoning blocks are removed instead of causing an upstream 400.
+pub(crate) fn normalize_reasoning_and_ids(body: &mut Value, request: &IrRequest) -> bool {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let original_len = input.len();
+    let anthropic_ingress = request.ingress_protocol.suite == ProtocolSuite::AnthropicMessages;
+    let signatures: Vec<Option<String>> = request
+        .messages
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .filter_map(|content| match content {
+            Content::Reasoning { signature, .. } if anthropic_ingress => Some(signature.clone()),
+            _ => None,
+        })
+        .collect();
+    let mut signature_index = 0usize;
+    let mut id_map = HashMap::new();
+    let mut changed = false;
+    let mut normalized = Vec::with_capacity(input.len());
+
+    for mut item in std::mem::take(input) {
+        let mut keep = true;
+        if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+            let mut valid_encrypted = item
+                .get("encrypted_content")
+                .and_then(Value::as_str)
+                .is_some_and(is_valid_gpt_reasoning_signature);
+
+            if anthropic_ingress {
+                let signature = signatures.get(signature_index).cloned().flatten();
+                signature_index += 1;
+                match signature.filter(|value| is_valid_gpt_reasoning_signature(value)) {
+                    Some(signature) => {
+                        item["summary"] = json!([]);
+                        item["encrypted_content"] = json!(signature);
+                        valid_encrypted = true;
+                        changed = true;
+                    }
+                    None => {
+                        // Claude thinking signatures cannot be replayed to
+                        // Codex. Match the native Codex translator and drop
+                        // the provider-specific reasoning item.
+                        keep = false;
+                        changed = true;
+                    }
+                }
+            } else if item.get("encrypted_content").is_some() && !valid_encrypted {
+                if let Some(object) = item.as_object_mut() {
+                    object.remove("encrypted_content");
+                }
+                changed = true;
+            }
+
+            if keep && !valid_encrypted {
+                if let Some(object) = item.as_object_mut() {
+                    // `store=false` means the upstream cannot resolve an
+                    // old reasoning item by id. Keep only id-less summaries.
+                    if object.remove("id").is_some() {
+                        changed = true;
+                    }
+                    let has_summary = object
+                        .get("summary")
+                        .and_then(Value::as_array)
+                        .is_some_and(|summary| !summary.is_empty());
+                    if !has_summary && !anthropic_ingress {
+                        keep = false;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        if keep {
+            for key in ["id", "call_id"] {
+                if let Some(value) = item.get(key).and_then(Value::as_str).map(str::to_string) {
+                    let shortened = shorten_codex_id(&value, &mut id_map);
+                    if shortened != value {
+                        item[key] = Value::String(shortened);
+                        changed = true;
+                    }
+                }
+            }
+            normalized.push(item);
+        }
+    }
+
+    if normalized.len() != original_len {
+        changed = true;
+    }
+    *input = normalized;
+    changed
+}
+
+/// Derive one stable Codex prompt-cache identity per Claude session and agent.
+pub(crate) fn claude_prompt_cache_key(
+    ingress_protocol: &ProtocolEndpoint,
+    request: &IrRequest,
+    client_headers: &HeaderMap,
+    model: &str,
+) -> Option<String> {
+    if ingress_protocol.suite != ProtocolSuite::AnthropicMessages {
+        return None;
+    }
+    let session = first_header(
+        client_headers,
+        [
+            "x-claude-code-session-id",
+            "x-session-id",
+            "session-id",
+            "session_id",
+        ],
+    )
+    .or_else(|| {
+        request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("user_id"))
+            .and_then(|value| claude_session_from_user_id(value))
+    })?;
+    let agent = first_header(client_headers, ["x-claude-code-agent-id"])
+        .unwrap_or_else(|| "main".to_string());
+    let identity = format!(
+        "tiygate:codex:claude-code\0{}\0{}\0{}",
+        model.trim(),
+        session,
+        agent
+    );
+    let digest = Sha256::digest(identity.as_bytes());
+    let mut uuid_bytes = [0u8; 16];
+    uuid_bytes.copy_from_slice(&digest[..16]);
+    uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x50;
+    uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80;
+    Some(uuid::Uuid::from_bytes(uuid_bytes).to_string())
+}
+
+pub(crate) fn set_prompt_cache_key(body: &mut Value, key: &str) -> bool {
+    if body.get("prompt_cache_key").and_then(Value::as_str) == Some(key) {
+        return false;
+    }
+    body["prompt_cache_key"] = Value::String(key.to_string());
+    true
+}
+
+/// Match Codex Responses Lite's serial tool-call contract and avoid sending a
+/// parallel flag when the request has no callable tools.
+pub(crate) fn normalize_parallel_tool_calls(body: &mut Value, headers: &HeaderMap) -> bool {
+    let lite_from_header = headers
+        .get("x-openai-internal-codex-responses-lite")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("true"));
+    let lite_from_body = body
+        .pointer("/client_metadata/ws_request_header_x_openai_internal_codex_responses_lite")
+        .is_some_and(|value| {
+            value.as_bool() == Some(true)
+                || value
+                    .as_str()
+                    .is_some_and(|text| text.trim().eq_ignore_ascii_case("true"))
+        });
+    if lite_from_header || lite_from_body {
+        if body.get("parallel_tool_calls").and_then(Value::as_bool) == Some(false) {
+            return false;
+        }
+        body["parallel_tool_calls"] = Value::Bool(false);
+        return true;
+    }
+
+    let has_tools = body
+        .get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| !tools.is_empty());
+    if !has_tools {
+        return body
+            .as_object_mut()
+            .is_some_and(|object| object.remove("parallel_tool_calls").is_some());
+    }
+    false
+}
+
+/// Apply Codex request headers after authentication has been injected.
+pub(crate) fn apply_request_headers(
+    headers: &mut HeaderMap,
+    is_stream: bool,
+    websocket: bool,
+    request_id: &str,
+    session_key: Option<&str>,
+    account_id: Option<&str>,
+) {
+    if !websocket {
+        let accept = if is_stream {
+            "text/event-stream"
+        } else {
+            "application/json"
+        };
+        set_header(headers, HeaderName::from_static("accept"), accept);
+    }
+    if !request_id.is_empty() {
+        insert_header_if_missing(
+            headers,
+            HeaderName::from_static("x-client-request-id"),
+            request_id,
+        );
+    }
+    let session_key = session_key
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            let has_session = ["session_id", "session-id"]
+                .iter()
+                .any(|name| headers.contains_key(*name));
+            let desktop_user_agent = headers
+                .get(http::header::USER_AGENT)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.contains("Mac OS"));
+            (!has_session && desktop_user_agent).then(|| uuid::Uuid::now_v7().to_string())
+        });
+    if let Some(session_key) = session_key.as_deref() {
+        let header = if websocket {
+            HeaderName::from_static("conversation_id")
+        } else {
+            HeaderName::from_static("session-id")
+        };
+        if websocket {
+            set_header(headers, header, session_key);
+        } else {
+            headers.remove("session_id");
+            headers.remove("session-id");
+            set_header(headers, header, session_key);
+        }
+    }
+    if let Some(account_id) = account_id.filter(|value| !value.is_empty()) {
+        insert_header_if_missing(
+            headers,
+            HeaderName::from_static("chatgpt-account-id"),
+            account_id,
+        );
+    }
+    insert_header_if_missing(
+        headers,
+        HeaderName::from_static("originator"),
+        "Codex Desktop",
+    );
+    insert_header_if_missing(
+        headers,
+        HeaderName::from_static("user-agent"),
+        "Codex Desktop",
+    );
+}
+
+fn set_header(headers: &mut HeaderMap, name: HeaderName, value: &str) {
+    if let Ok(value) = HeaderValue::from_str(value) {
+        headers.insert(name, value);
+    }
+}
+
+fn insert_header_if_missing(headers: &mut HeaderMap, name: HeaderName, value: &str) {
+    if headers.contains_key(&name) {
+        return;
+    }
+    if let Ok(value) = HeaderValue::from_str(value) {
+        headers.insert(name, value);
+    }
+}
+
+fn first_header<const N: usize>(headers: &HeaderMap, names: [&str; N]) -> Option<String> {
+    names.iter().find_map(|name| {
+        headers
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn claude_session_from_user_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if value.starts_with('{') {
+        if let Ok(parsed) = serde_json::from_str::<Value>(value) {
+            if let Some(session) = parsed.get("session_id").and_then(Value::as_str) {
+                if !session.trim().is_empty() {
+                    return Some(session.trim().to_string());
+                }
+            }
+        }
+    }
+    value
+        .rsplit_once("_session_")
+        .map(|(_, session)| session.trim())
+        .filter(|session| {
+            !session.is_empty()
+                && session
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+        })
+        .map(str::to_string)
+}
+
+fn strip_prompt_cache_breakpoints(body: &mut Value) -> bool {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let mut changed = false;
+    for item in input {
+        if let Some(content) = item.get_mut("content").and_then(Value::as_array_mut) {
+            for part in content {
+                if let Some(object) = part.as_object_mut() {
+                    changed |= object.remove("prompt_cache_breakpoint").is_some();
+                }
+            }
+        }
+    }
+    changed
+}
+
+fn normalize_codex_input_ids(body: &mut Value) -> bool {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let mut id_map = HashMap::new();
+    let mut changed = false;
+    for item in input {
+        for key in ["id", "call_id"] {
+            if let Some(value) = item.get(key).and_then(Value::as_str).map(str::to_string) {
+                let shortened = shorten_codex_id(&value, &mut id_map);
+                if shortened != value {
+                    item[key] = Value::String(shortened);
+                    changed = true;
+                }
+            }
+        }
+    }
+    changed
+}
+
+fn shorten_codex_id(id: &str, id_map: &mut HashMap<String, String>) -> String {
+    if id.chars().count() <= 64 {
+        return id.to_string();
+    }
+    if let Some(mapped) = id_map.get(id) {
+        return mapped.clone();
+    }
+    let digest = Sha256::digest(id.as_bytes());
+    let suffix = format!("_{}", hex::encode(&digest[..8]));
+    let prefix_len = 64usize.saturating_sub(suffix.chars().count());
+    let shortened = format!(
+        "{}{}",
+        id.chars().take(prefix_len).collect::<String>(),
+        suffix
+    );
+    id_map.insert(id.to_string(), shortened.clone());
+    shortened
+}
+
+fn is_valid_gpt_reasoning_signature(signature: &str) -> bool {
+    let trimmed = signature.trim();
+    if trimmed != signature {
+        return false;
+    }
+    let signature = trimmed;
+    if signature.is_empty() || signature.len() > 32 * 1024 * 1024 || !signature.starts_with("gAAAA")
+    {
+        return false;
+    }
+    if !signature
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'='))
+    {
+        return false;
+    }
+    let decoded = general_purpose::URL_SAFE_NO_PAD
+        .decode(signature)
+        .or_else(|_| general_purpose::URL_SAFE.decode(signature));
+    let Ok(decoded) = decoded else {
+        return false;
+    };
+    if decoded.len() < 73 || decoded[0] != 0x80 {
+        return false;
+    }
+    let ciphertext_len = decoded.len().saturating_sub(1 + 8 + 16 + 32);
+    ciphertext_len > 0 && ciphertext_len % 16 == 0
 }
 
 /// Parse either a JSON response or the terminal event from a Codex HTTP/SSE response.
@@ -228,8 +727,9 @@ pub(crate) fn normalize_websocket_event(text: String) -> (String, bool) {
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use tiygate_core::provider::oauth::{OAuthTargetConfig, TokenRequestStyle};
-    use tiygate_core::ProtocolEndpoint;
+    use tiygate_core::{Content, IrRequest, Message, ProtocolEndpoint, Role};
 
     fn target(profile: OAuthEgressProfile, transport: UpstreamTransport) -> RoutingTarget {
         RoutingTarget {
@@ -289,9 +789,27 @@ mod tests {
                 "model": "gpt-5.6",
                 "stream": false,
                 "instructions": null,
-                "input": "hi",
+                "input": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "hi",
+                        "prompt_cache_breakpoint": {"mode": "explicit"}
+                    }]
+                }],
                 "metadata": {"user_id": "user-123"},
                 "max_output_tokens": 4096,
+                "max_completion_tokens": 4096,
+                "temperature": 0.2,
+                "top_p": 0.8,
+                "stop": ["DONE"],
+                "user": "request-owner",
+                "truncation": "auto",
+                "prompt_cache_options": {"mode": "implicit"},
+                "context_management": [{"type": "compaction"}],
+                "generate": true,
+                "service_tier": "standard",
                 "prompt_cache_retention": "24h",
                 "safety_identifier": "user",
                 "previous_response_id": "resp-old",
@@ -302,12 +820,26 @@ mod tests {
             assert_eq!(body["instructions"], "");
             assert_eq!(body["store"], false);
             assert_eq!(body["model"], "gpt-5.6");
-            assert_eq!(body["input"], "hi");
+            assert_eq!(body["input"][0]["content"][0]["text"], "hi");
+            assert!(body["input"][0]["content"][0]
+                .get("prompt_cache_breakpoint")
+                .is_none());
             assert!(body.get("metadata").is_none());
             assert!(
                 body.get("max_output_tokens").is_none(),
                 "ChatGPT Codex backend rejects max_output_tokens (websocket={websocket})"
             );
+            assert!(body.get("temperature").is_none());
+            assert!(body.get("top_p").is_none());
+            assert!(body.get("stop").is_none());
+            assert!(body.get("user").is_none());
+            assert!(body.get("truncation").is_none());
+            assert!(body.get("prompt_cache_options").is_none());
+            assert!(body.get("context_management").is_none());
+            assert!(body.get("generate").is_none());
+            assert!(body.get("service_tier").is_none());
+            assert_eq!(body["include"][0], "reasoning.encrypted_content");
+            assert_eq!(body["parallel_tool_calls"], true);
             assert!(body.get("prompt_cache_retention").is_none());
             assert!(body.get("safety_identifier").is_none());
             // HTTP strips these; the WebSocket transport keeps them.
@@ -341,8 +873,199 @@ mod tests {
                 "instructions": "",
                 "store": false,
             });
-            assert!(!prepare_body(&mut disabled, websocket));
+            assert!(prepare_body(&mut disabled, websocket));
             assert_eq!(disabled["store"], false);
+            assert_eq!(disabled["include"][0], "reasoning.encrypted_content");
         }
+    }
+
+    #[test]
+    fn prepare_body_normalizes_input_shape_and_system_role() {
+        let mut string_input = json!({
+            "input": "hello",
+            "service_tier": "priority"
+        });
+        assert!(prepare_body(&mut string_input, false));
+        assert_eq!(string_input["input"][0]["role"], "user");
+        assert_eq!(string_input["input"][0]["content"][0]["text"], "hello");
+        assert_eq!(string_input["service_tier"], "priority");
+
+        let mut system_input = json!({
+            "input": [{"type": "message", "role": "system", "content": "rule"}]
+        });
+        assert!(prepare_body(&mut system_input, false));
+        assert_eq!(system_input["input"][0]["role"], "developer");
+    }
+
+    #[test]
+    fn validate_codex_tool_names_rejects_names_over_64_bytes() {
+        let body = json!({
+            "tools": [{"type": "function", "name": "x".repeat(65)}]
+        });
+        let error = validate_codex_tool_names(&body).unwrap_err();
+        assert_eq!(error.http_status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error.upstream_error_code(), Some("unsupported_tool_name"));
+    }
+
+    fn anthropic_request_with_reasoning(signature: Option<String>) -> IrRequest {
+        IrRequest {
+            model: "gpt-5.6".to_string(),
+            system: None,
+            messages: vec![Message {
+                role: Role::Assistant,
+                content: vec![Content::Reasoning {
+                    text: "summary".to_string(),
+                    signature,
+                    id: None,
+                    encrypted_content: None,
+                }],
+            }],
+            tools: Vec::new(),
+            params: Default::default(),
+            response_format: None,
+            stream: false,
+            ingress_protocol: ProtocolEndpoint::new(
+                ProtocolSuite::AnthropicMessages,
+                "messages",
+                "2023-06-01",
+            ),
+            metadata: None,
+            extensions: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn normalize_reasoning_drops_foreign_signature_and_shortens_ids() {
+        let mut body = json!({
+            "store": false,
+            "input": [
+                {"type": "reasoning", "id": "rs_foreign", "summary": [{"type": "summary_text", "text": "x"}]},
+                {"type": "function_call", "id": "call_abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz", "call_id": "call_abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz", "name": "lookup", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "call_abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz", "output": "ok"}
+            ]
+        });
+        let request =
+            anthropic_request_with_reasoning(Some("claude-foreign-signature".to_string()));
+
+        assert!(normalize_reasoning_and_ids(&mut body, &request));
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input.len(), 2);
+        assert!(input.iter().all(|item| item["type"] != "reasoning"));
+        assert!(input[0]["id"].as_str().unwrap().len() <= 64);
+        assert!(input[0]["call_id"].as_str().unwrap().len() <= 64);
+        assert_eq!(input[0]["call_id"], input[1]["call_id"]);
+    }
+
+    #[test]
+    fn normalize_reasoning_preserves_valid_gpt_encrypted_content() {
+        let mut decoded = vec![0x80u8];
+        decoded.extend([0u8; 8 + 16 + 16 + 32]);
+        let signature = general_purpose::URL_SAFE_NO_PAD.encode(decoded);
+        let mut body = json!({
+            "store": false,
+            "input": [{"type": "reasoning", "id": "rs_valid", "summary": [{"type": "summary_text", "text": "x"}]}]
+        });
+        let request = anthropic_request_with_reasoning(Some(signature.clone()));
+
+        assert!(normalize_reasoning_and_ids(&mut body, &request));
+        assert_eq!(body["input"][0]["encrypted_content"], signature);
+        assert_eq!(body["input"][0]["summary"], json!([]));
+        assert_eq!(body["input"][0]["id"], "rs_valid");
+    }
+
+    #[test]
+    fn normalize_reasoning_drops_whitespace_padded_gpt_signature() {
+        let mut decoded = vec![0x80u8];
+        decoded.extend([0u8; 8 + 16 + 16 + 32]);
+        let signature = general_purpose::URL_SAFE_NO_PAD.encode(decoded);
+        let mut body = json!({
+            "store": false,
+            "input": [{"type": "reasoning", "encrypted_content": format!(" {signature}")}]
+        });
+        let request = anthropic_request_with_reasoning(Some(format!(" {signature}")));
+
+        assert!(normalize_reasoning_and_ids(&mut body, &request));
+        assert!(body["input"].as_array().is_some_and(Vec::is_empty));
+    }
+
+    #[test]
+    fn claude_session_cache_key_is_stable_and_agent_scoped() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "user_id".to_string(),
+            r#"{"device_id":"d","session_id":"session-1"}"#.to_string(),
+        );
+        let mut request = anthropic_request_with_reasoning(None);
+        request.metadata = Some(metadata);
+        let protocol = request.ingress_protocol.clone();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-claude-code-agent-id"),
+            HeaderValue::from_static("agent-a"),
+        );
+
+        let first = claude_prompt_cache_key(&protocol, &request, &headers, "gpt-5.6").unwrap();
+        let second = claude_prompt_cache_key(&protocol, &request, &headers, "gpt-5.6").unwrap();
+        assert_eq!(first, second);
+        headers.insert(
+            HeaderName::from_static("x-claude-code-agent-id"),
+            HeaderValue::from_static("agent-b"),
+        );
+        let other_agent =
+            claude_prompt_cache_key(&protocol, &request, &headers, "gpt-5.6").unwrap();
+        assert_ne!(first, other_agent);
+    }
+
+    #[test]
+    fn claude_prompt_cache_key_rejects_bare_user_id() {
+        let mut metadata = HashMap::new();
+        metadata.insert("user_id".to_string(), "same-user-across-chats".to_string());
+        let mut request = anthropic_request_with_reasoning(None);
+        request.metadata = Some(metadata);
+
+        assert!(claude_prompt_cache_key(
+            &request.ingress_protocol.clone(),
+            &request,
+            &HeaderMap::new(),
+            "gpt-5.6"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn apply_request_headers_sets_codex_http_and_websocket_identity() {
+        let mut http_headers = HeaderMap::new();
+        apply_request_headers(
+            &mut http_headers,
+            true,
+            false,
+            "request-1",
+            Some("cache-1"),
+            Some("account-1"),
+        );
+        assert_eq!(http_headers["accept"], "text/event-stream");
+        assert_eq!(http_headers["x-client-request-id"], "request-1");
+        assert_eq!(http_headers["session-id"], "cache-1");
+        assert_eq!(http_headers["chatgpt-account-id"], "account-1");
+        assert_eq!(http_headers["originator"], "Codex Desktop");
+
+        http_headers.insert(
+            HeaderName::from_static("accept"),
+            HeaderValue::from_static("application/json"),
+        );
+        apply_request_headers(&mut http_headers, true, false, "", None, None);
+        assert_eq!(http_headers["accept"], "text/event-stream");
+
+        let mut websocket_headers = HeaderMap::new();
+        apply_request_headers(
+            &mut websocket_headers,
+            true,
+            true,
+            "request-1",
+            Some("cache-1"),
+            None,
+        );
+        assert!(websocket_headers.get("accept").is_none());
+        assert_eq!(websocket_headers["conversation_id"], "cache-1");
     }
 }

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -502,8 +502,11 @@ async fn test_anthropic_messages_to_codex_responses_strips_unsupported_metadata(
     let body = json!({
         "model": "gpt-5.6-luna",
         "max_tokens": 32000,
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "stop_sequences": ["DONE"],
         "messages": [{"role": "user", "content": "Hello"}],
-        "metadata": {"user_id": "opaque-user-id"}
+        "metadata": {"user_id": "{\"device_id\":\"device-issue-52\",\"session_id\":\"issue-52-session\"}"}
     });
     let request = Request::builder()
         .method("POST")
@@ -528,8 +531,17 @@ async fn test_anthropic_messages_to_codex_responses_strips_unsupported_metadata(
     assert_eq!(upstream_body["stream"], true);
     assert_eq!(upstream_body["instructions"], "");
     assert_eq!(upstream_body["store"], false);
+    assert!(
+        upstream_body["prompt_cache_key"]
+            .as_str()
+            .is_some_and(|key| uuid::Uuid::parse_str(key).is_ok()),
+        "Claude session should produce a stable Codex prompt_cache_key: {upstream_body}"
+    );
     assert!(upstream_body.get("metadata").is_none());
     assert!(upstream_body.get("max_output_tokens").is_none());
+    assert!(upstream_body.get("temperature").is_none());
+    assert!(upstream_body.get("top_p").is_none());
+    assert!(upstream_body.get("stop").is_none());
 
     cache.invalidate_provider(provider_id);
 }

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -14,10 +14,15 @@
 )]
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::json;
+use tiygate_auth::provider_oauth::OAuthTokenCache;
+use tiygate_core::provider::oauth::{
+    OAuthEgressProfile, OAuthTargetConfig, TokenRequestStyle, UpstreamTransport,
+};
 use tiygate_core::quota::InMemoryQuota;
 use tiygate_core::{HealthRegistry, ProtocolEndpoint, ProtocolSuite, RoutingTable};
 use tiygate_server::config::ServerConfig;
@@ -106,6 +111,51 @@ fn build_anthropic_test_app_with_config(
 
     let config_store = ConfigStore::with_routing_table(routing_table);
     let health = Arc::new(HealthRegistry::with_defaults());
+    ingress::router(config_store, health, &server_config)
+}
+
+/// Build an Anthropic Messages ingress app whose target uses the Codex OAuth
+/// Responses profile. The access token is seeded by the test before sending a
+/// request, so no token endpoint is needed for this data-plane regression.
+fn build_anthropic_ingress_codex_egress_app(
+    upstream_url: String,
+    model: &str,
+    provider_id: &str,
+) -> axum::Router {
+    let mut routing_table = RoutingTable::new();
+    routing_table.insert(
+        model.to_string(),
+        vec![tiygate_core::RoutingTarget {
+            provider_id: provider_id.to_string(),
+            model_id: model.to_string(),
+            api_base: upstream_url,
+            api_key: String::new(),
+            api_protocol: ProtocolEndpoint::new(ProtocolSuite::OpenAiResponses, "responses", "v1"),
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            weight: 1.0,
+            oauth: Some(OAuthTargetConfig {
+                upstream_transport: UpstreamTransport::Http,
+                egress_profile: OAuthEgressProfile::OpenAiCodex,
+                token_url: "https://example.test/token".to_string(),
+                client_id: "codex-test-client".to_string(),
+                client_secret: None,
+                refresh_token: "refresh-token".to_string(),
+                scopes: Vec::new(),
+                token_request_style: TokenRequestStyle::Form,
+                authorization_header: None,
+                authorization_prefix: None,
+                extra_headers: Vec::new(),
+                account_id: None,
+            }),
+        }],
+    );
+
+    let config_store = ConfigStore::with_routing_table(routing_table);
+    let health = Arc::new(HealthRegistry::with_defaults());
+    let mut server_config = ServerConfig::default();
+    server_config.require_api_key = false;
     ingress::router(config_store, health, &server_config)
 }
 
@@ -413,6 +463,75 @@ async fn test_happy_path_anthropic_messages() {
     let body_str = String::from_utf8_lossy(&body_bytes);
     assert!(body_str.contains("Hi from Anthropic wiremock!"));
     assert!(body_str.contains("\"role\":\"assistant\""));
+}
+
+#[tokio::test]
+async fn test_anthropic_messages_to_codex_responses_strips_unsupported_metadata() {
+    let mock_server = wiremock::MockServer::start().await;
+    let provider_id = "issue-52-codex-metadata";
+    let cache = OAuthTokenCache::global();
+    cache.invalidate_provider(provider_id);
+    cache.seed_tokens(
+        provider_id,
+        "__provider__",
+        "access-token",
+        "refresh-token",
+        Some(Duration::from_secs(300)),
+    );
+
+    let upstream_sse = concat!(
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_issue_52\",\"object\":\"response\",\"status\":\"in_progress\"}}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_issue_52\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"gpt-5.6-luna\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello from Codex\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":4,\"total_tokens\":7}}}\n\n"
+    );
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/responses"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer access-token",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(upstream_sse),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let app =
+        build_anthropic_ingress_codex_egress_app(mock_server.uri(), "gpt-5.6-luna", provider_id);
+    let body = json!({
+        "model": "gpt-5.6-luna",
+        "max_tokens": 32000,
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {"user_id": "opaque-user-id"}
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&response_body).unwrap();
+    assert_eq!(response_json["type"], "message");
+    assert_eq!(response_json["content"][0]["text"], "Hello from Codex");
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let upstream_body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(upstream_body["model"], "gpt-5.6-luna");
+    assert_eq!(upstream_body["stream"], true);
+    assert_eq!(upstream_body["instructions"], "");
+    assert_eq!(upstream_body["store"], false);
+    assert!(upstream_body.get("metadata").is_none());
+    assert!(upstream_body.get("max_output_tokens").is_none());
+
+    cache.invalidate_provider(provider_id);
 }
 
 #[tokio::test]

--- a/docs/oauth-token-lifecycle.md
+++ b/docs/oauth-token-lifecycle.md
@@ -60,8 +60,13 @@ The provider vendor selects an immutable `OAuthEgressProfile`:
   the shared upstream client; Codex does not maintain a separate HTTP pool.
   The profile is applied after protocol conversion on every ingress path and
   removes fields unsupported by the ChatGPT subscription backend, including
-  `metadata` and `max_output_tokens`; public OpenAI Responses egress keeps
-  those fields unchanged.
+  `metadata`, `temperature`, `top_p`, `stop`, `user`, `truncation`, cache
+  options, and output-token fields; it forces `store: false`, requests
+  encrypted reasoning content, scopes Claude Code prompt-cache identity by
+  session and agent, and applies Codex session/account headers. Public OpenAI
+  Responses egress keeps those fields unchanged. TiyGate uses verified rustls
+  transport, rejects tool names over Codex's 64-byte limit with a capability
+  error, and does not impersonate a browser TLS fingerprint.
 - Anthropic OAuth uses `anthropic_oauth` only for Anthropic Messages egress.
   The profile owns OAuth beta and client headers, summarized-thinking defaults,
   re-signing of an existing billing header, and a dedicated verified-Rustls

--- a/docs/oauth-token-lifecycle.md
+++ b/docs/oauth-token-lifecycle.md
@@ -58,6 +58,10 @@ The provider vendor selects an immutable `OAuthEgressProfile`:
   terminal-response parsing, and WebSocket negotiation. `UpstreamTransport`
   independently selects HTTP/SSE or Codex Responses WebSocket. HTTP/SSE uses
   the shared upstream client; Codex does not maintain a separate HTTP pool.
+  The profile is applied after protocol conversion on every ingress path and
+  removes fields unsupported by the ChatGPT subscription backend, including
+  `metadata` and `max_output_tokens`; public OpenAI Responses egress keeps
+  those fields unchanged.
 - Anthropic OAuth uses `anthropic_oauth` only for Anthropic Messages egress.
   The profile owns OAuth beta and client headers, summarized-thinking defaults,
   re-signing of an existing billing header, and a dedicated verified-Rustls

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -153,7 +153,7 @@ Multi-agent 仍要求客户端显式提供 `OpenAI-Beta: responses_multi_agent=v
 | `metadata` KV 对 | ✅ | ⚠️ → 仅保留 `user_id` | ✅ | ✅ (`labels`) | N/A |
 | `user_id` | ✅ | ✅ | ✅ | ✅ | N/A |
 
-**跨协议策略**：Anthropic 只支持 `user_id` 键，其他键静默丢弃（与官方 API 一致）。
+**跨协议策略**：Anthropic 只支持 `user_id` 键，其他键静默丢弃（与官方 API 一致）。公开 OpenAI Responses 支持顶层 `metadata`；但 `openai_codex` OAuth egress 面向 ChatGPT/Codex 私有后端，会在发送前丢弃该字段，并保留网关内部审计数据。
 
 ## 8. Annotations / Citations
 

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -153,7 +153,7 @@ Multi-agent 仍要求客户端显式提供 `OpenAI-Beta: responses_multi_agent=v
 | `metadata` KV 对 | ✅ | ⚠️ → 仅保留 `user_id` | ✅ | ✅ (`labels`) | N/A |
 | `user_id` | ✅ | ✅ | ✅ | ✅ | N/A |
 
-**跨协议策略**：Anthropic 只支持 `user_id` 键，其他键静默丢弃（与官方 API 一致）。公开 OpenAI Responses 支持顶层 `metadata`；但 `openai_codex` OAuth egress 面向 ChatGPT/Codex 私有后端，会在发送前丢弃该字段，并保留网关内部审计数据。
+**跨协议策略**：Anthropic 只支持 `user_id` 键，其他键静默丢弃（与官方 API 一致）。公开 OpenAI Responses 支持顶层 `metadata`；但 `openai_codex` OAuth egress 面向 ChatGPT/Codex 私有后端，会在发送前丢弃不兼容字段，并保留网关内部审计数据。Codex egress 还会清洗嵌套 cache breakpoint、校验 reasoning encrypted content，并按 Claude Code session/agent 派生 prompt-cache identity。
 
 ## 8. Annotations / Citations
 
@@ -179,7 +179,7 @@ Multi-agent 仍要求客户端显式提供 `OpenAI-Beta: responses_multi_agent=v
 |------|:---:|:---:|:---:|:---:|:---:|
 | `encrypted_content` | ⚠️ → 丢弃 | ✅ (`redacted_thinking.data`) | ✅ (`reasoning.encrypted_content`) | ⚠️ → 丢弃 | N/A |
 
-**跨协议策略**：encrypted_content 仅在同协议往返时保留（Responses ↔ Responses, Anthropic ↔ Anthropic），跨协议时丢弃（加密数据是协议特定的）。
+**跨协议策略**：一般跨协议时丢弃 encrypted_content（加密数据是协议特定的）；但 `openai_codex` OAuth egress 对 Anthropic thinking signature 做 GPT/Codex 外层格式校验，只有有效 signature 才转换为 Responses `reasoning.encrypted_content`，非法或其他供应商 signature 仍会丢弃。
 
 ## 11. Stop Details
 


### PR DESCRIPTION
## Summary
- Preserve Codex-specific OAuth metadata through the ingress execution path.
- Update Codex OAuth handling and related dependency configuration.
- Add wiremock coverage for Codex provider request behavior.
- Document the OAuth token lifecycle and protocol capability implications.
- Related issue: #52

## Testing
- Added or updated wiremock provider integration coverage.
- Not run locally (not requested).

Closes #52