### PR TITLE
Add provider usage-management key support

### DIFF
--- a/crates/admin/src/handlers.rs
+++ b/crates/admin/src/handlers.rs
@@ -30,6 +30,8 @@ use crate::state::AdminState;
 
 const OPENAI_PLATFORM_BASE_URL: &str = "https://api.openai.com/v1";
 const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+const ZENMUX_DEFAULT_API_BASE_URL: &str = "https://zenmux.ai/api";
+const ZENMUX_MANAGEMENT_USAGE_PATH: &str = "/v1/management/subscription/detail";
 /// ChatGPT/Codex subscription usage endpoint. This endpoint is used only for
 /// OpenAI OAuth providers; OpenAI API-key providers have platform billing
 /// semantics rather than the ChatGPT 5-hour / 7-day windows.
@@ -581,6 +583,154 @@ fn parse_anthropic_usage(body: &str) -> Result<ParsedProviderUsage, String> {
     Ok(ParsedProviderUsage { plan_type, windows })
 }
 
+fn parse_json_f64(value: Option<&Value>) -> Option<f64> {
+    let value = value?;
+    value
+        .as_f64()
+        .or_else(|| value.as_i64().map(|value| value as f64))
+        .or_else(|| value.as_u64().map(|value| value as f64))
+        .or_else(|| {
+            value
+                .as_str()
+                .and_then(|raw| raw.trim().parse::<f64>().ok())
+        })
+}
+
+fn parse_json_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn normalize_zenmux_used_percent(value: f64) -> Option<f64> {
+    value.is_finite().then(|| {
+        let percent = if (-1.0..=1.0).contains(&value) {
+            value * 100.0
+        } else {
+            value
+        };
+        percent.clamp(0.0, 100.0)
+    })
+}
+
+fn map_zenmux_usage_window(
+    value: Option<&Value>,
+    default_window_seconds: i64,
+) -> Option<ProviderUsageWindow> {
+    let object = value?.as_object()?;
+    let max_flows = parse_json_f64(object.get("max_flows").or_else(|| object.get("maxFlows")));
+    let used_flows = parse_json_f64(object.get("used_flows").or_else(|| object.get("usedFlows")));
+    let remaining_flows = parse_json_f64(
+        object
+            .get("remaining_flows")
+            .or_else(|| object.get("remainingFlows")),
+    );
+    let used_percent = parse_json_f64(
+        object
+            .get("usage_percentage")
+            .or_else(|| object.get("usagePercentage"))
+            .or_else(|| object.get("used_percent"))
+            .or_else(|| object.get("used_percentage")),
+    )
+    .and_then(normalize_zenmux_used_percent)
+    .or_else(|| {
+        let max_flows = max_flows.filter(|value| value.is_finite() && *value > 0.0)?;
+        let used_flows = used_flows.filter(|value| value.is_finite())?;
+        normalize_zenmux_used_percent((used_flows / max_flows).clamp(0.0, 1.0))
+    })
+    .or_else(|| {
+        let max_flows = max_flows.filter(|value| value.is_finite() && *value > 0.0)?;
+        let remaining_flows = remaining_flows.filter(|value| value.is_finite())?;
+        normalize_zenmux_used_percent(((max_flows - remaining_flows) / max_flows).clamp(0.0, 1.0))
+    });
+    let reset_at = parse_usage_reset_at(
+        object
+            .get("resets_at")
+            .or_else(|| object.get("resetsAt"))
+            .or_else(|| object.get("reset_at"))
+            .or_else(|| object.get("resetAt")),
+    );
+    let limit_window_seconds = object
+        .get("limit_window_seconds")
+        .or_else(|| object.get("limitWindowSeconds"))
+        .and_then(|value| parse_json_f64(Some(value)))
+        .and_then(|value| i64::try_from(value as i128).ok())
+        .filter(|seconds| *seconds > 0)
+        .or(Some(default_window_seconds));
+    (used_percent.is_some() || reset_at.is_some()).then_some(ProviderUsageWindow {
+        label: None,
+        used_percent,
+        reset_at,
+        limit_window_seconds,
+    })
+}
+
+fn zenmux_plan_type(value: Option<&Value>) -> Option<String> {
+    let value = value?;
+    parse_json_string(Some(value)).or_else(|| {
+        let object = value.as_object()?;
+        ["tier", "name", "type", "plan_type"]
+            .into_iter()
+            .find_map(|key| parse_json_string(object.get(key)))
+    })
+}
+
+fn parse_zenmux_usage(body: &str) -> Result<ParsedProviderUsage, String> {
+    let response: Value =
+        serde_json::from_str(body).map_err(|error| format!("invalid usage response: {error}"))?;
+    let object = response
+        .as_object()
+        .ok_or_else(|| "usage response is not an object".to_string())?;
+    if object.get("success").and_then(Value::as_bool) == Some(false) {
+        let message = parse_json_string(object.get("message"))
+            .unwrap_or_else(|| "ZenMux subscription API returned success=false".to_string());
+        return Err(message);
+    }
+    let data = object
+        .get("data")
+        .filter(|value| !value.is_null())
+        .unwrap_or(&response);
+    let data_object = data
+        .as_object()
+        .ok_or_else(|| "subscription response data is not an object".to_string())?;
+    let plan_type = zenmux_plan_type(data_object.get("plan"))
+        .or_else(|| parse_json_string(data_object.get("plan_type")))
+        .or_else(|| parse_json_string(data_object.get("subscription_type")))
+        .or_else(|| zenmux_plan_type(data_object.get("tier")));
+    let windows = [
+        ("quota_5_hour", FIVE_HOURS_SECONDS),
+        ("quota_7_day", SEVEN_DAYS_SECONDS),
+    ]
+    .into_iter()
+    .filter_map(|(key, duration)| map_zenmux_usage_window(data_object.get(key), duration))
+    .collect::<Vec<_>>();
+    if windows.is_empty() {
+        return Err("subscription response has no supported quota windows".to_string());
+    }
+    Ok(ParsedProviderUsage { plan_type, windows })
+}
+
+fn zenmux_subscription_usage_url(provider: &Provider) -> Option<String> {
+    let configured = provider.api_base.trim().trim_end_matches('/');
+    let configured = if configured.is_empty() {
+        ZENMUX_DEFAULT_API_BASE_URL
+    } else {
+        configured
+    };
+    if configured.is_empty() {
+        return None;
+    }
+    let base = configured.strip_suffix("/v1").unwrap_or(configured);
+    let api_base = if base.ends_with("/api") {
+        base.to_string()
+    } else {
+        format!("{base}/api")
+    };
+    Some(format!("{api_base}{ZENMUX_MANAGEMENT_USAGE_PATH}"))
+}
+
 fn provider_oauth_account_email(provider: &Provider) -> Option<String> {
     provider
         .oauth_meta_cleartext
@@ -791,9 +941,151 @@ async fn prepare_oauth_usage_request(
     Ok((client, headers, account_email))
 }
 
-/// Fetch subscription usage windows for one supported OAuth provider. The
-/// OAuth cache is keyed by provider/account, so multiple providers can safely
-/// use different upstream accounts in one process.
+async fn fetch_zenmux_usage(provider_id: &str, provider: &Provider) -> ProviderUsageResponse {
+    let missing_key_reason = if provider.encrypted_usage_management_key.is_empty() {
+        "management_key_missing"
+    } else {
+        "management_key_unavailable"
+    };
+    let Some(management_key) = provider
+        .usage_management_key_cleartext
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+    else {
+        return provider_usage_response(
+            provider_id,
+            if missing_key_reason == "management_key_missing" {
+                "not_connected"
+            } else {
+                "unavailable"
+            },
+            Some(missing_key_reason),
+            Vec::new(),
+            None,
+        );
+    };
+    let Some(usage_url) = zenmux_subscription_usage_url(provider) else {
+        return provider_usage_response(
+            provider_id,
+            "unavailable",
+            Some("invalid_api_base"),
+            Vec::new(),
+            None,
+        );
+    };
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider_id,
+                error = %error,
+                "ZenMux usage HTTP client build failed"
+            );
+            return provider_usage_response(
+                provider_id,
+                "unavailable",
+                Some("http_client_unavailable"),
+                Vec::new(),
+                None,
+            );
+        }
+    };
+    let response = match client
+        .get(&usage_url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {management_key}"),
+        )
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider_id,
+                error = %error,
+                "ZenMux subscription usage request failed"
+            );
+            return provider_usage_response(
+                provider_id,
+                "unavailable",
+                Some("upstream_request_failed"),
+                Vec::new(),
+                None,
+            );
+        }
+    };
+    if !response.status().is_success() {
+        let status = response.status();
+        tracing::warn!(
+            provider = %provider_id,
+            status = %status,
+            "ZenMux subscription usage endpoint returned an error"
+        );
+        return provider_usage_response(
+            provider_id,
+            "unavailable",
+            Some(
+                if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+                    "management_key_rejected"
+                } else {
+                    "upstream_http_error"
+                },
+            ),
+            Vec::new(),
+            None,
+        );
+    }
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider_id,
+                error = %error,
+                "ZenMux subscription usage response read failed"
+            );
+            return provider_usage_response(
+                provider_id,
+                "unavailable",
+                Some("upstream_response_read_failed"),
+                Vec::new(),
+                None,
+            );
+        }
+    };
+    let parsed = match parse_zenmux_usage(&body) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider_id,
+                error = %error,
+                "ZenMux subscription usage response parse failed"
+            );
+            return provider_usage_response(
+                provider_id,
+                "unavailable",
+                Some("invalid_upstream_response"),
+                Vec::new(),
+                None,
+            );
+        }
+    };
+    let mut usage = provider_usage_response(provider_id, "available", None, parsed.windows, None);
+    usage.plan_type = parsed.plan_type;
+    usage
+}
+
+/// Fetch subscription usage windows for supported OAuth providers and the
+/// optional ZenMux Management API key. The OAuth cache is keyed by
+/// provider/account, so multiple providers can safely use different upstream
+/// accounts in one process.
 async fn provider_usage(
     State(state): State<AdminState>,
     Path(id): Path<String>,
@@ -803,6 +1095,9 @@ async fn provider_usage(
         .get_provider(&id)
         .await?
         .ok_or_else(|| AdminError::NotFound(format!("provider {id}")))?;
+    if provider.vendor.eq_ignore_ascii_case("zenmux") {
+        return Ok(Json(fetch_zenmux_usage(&id, &provider).await).into_response());
+    }
     let stored_account_email = provider_oauth_account_email(&provider);
 
     if !matches!(provider.auth_mode, AuthMode::OAuth) {
@@ -1548,7 +1843,8 @@ async fn info() -> impl IntoResponse {
 // delete records the snapshot of the removed object.
 
 /// Build a redacted JSON snapshot of a provider. Sensitive credentials
-/// (`api_key`, `oauth_meta`) go through [`KeyEncryption::redact`] so the
+/// (`api_key`, `usage_management_key`, `oauth_meta`) go through
+/// [`KeyEncryption::redact`] so the
 /// audit table never stores cleartext secrets.
 fn provider_snapshot(p: &Provider) -> serde_json::Value {
     json!({
@@ -1561,6 +1857,9 @@ fn provider_snapshot(p: &Provider) -> serde_json::Value {
         "enabled": p.enabled,
         "metadata": p.metadata_json,
         "api_key": tiygate_store::encryption::KeyEncryption::redact(&p.encrypted_api_key),
+        "usage_management_key": tiygate_store::encryption::KeyEncryption::redact(
+            &p.encrypted_usage_management_key,
+        ),
         "oauth_meta": tiygate_store::encryption::KeyEncryption::redact(&p.encrypted_oauth_meta),
     })
 }
@@ -1650,6 +1949,9 @@ struct ProviderRequest {
     api_base: String,
     models_endpoint: Option<String>,
     api_key: Option<String>,
+    /// Optional provider-specific key used only for subscription usage
+    /// requests (currently supported by ZenMux). Blank clears it.
+    usage_management_key: Option<String>,
     auth_mode: Option<String>,
     oauth_meta: Option<String>,
     metadata: Option<serde_json::Value>,
@@ -1672,6 +1974,7 @@ struct ProviderView {
     models_endpoint: String,
     auth_mode: String,
     encrypted_api_key: String,
+    encrypted_usage_management_key: String,
     encrypted_oauth_meta: String,
     oauth_status: Option<ProviderOAuthStatusView>,
     metadata: serde_json::Value,
@@ -1696,6 +1999,9 @@ impl From<Provider> for ProviderView {
             auth_mode: p.auth_mode.as_str().to_string(),
             encrypted_api_key: tiygate_store::encryption::KeyEncryption::redact(
                 &p.encrypted_api_key,
+            ),
+            encrypted_usage_management_key: tiygate_store::encryption::KeyEncryption::redact(
+                &p.encrypted_usage_management_key,
             ),
             encrypted_oauth_meta: tiygate_store::encryption::KeyEncryption::redact(
                 &p.encrypted_oauth_meta,
@@ -1763,6 +2069,9 @@ fn provider_oauth_status(provider: &Provider) -> ProviderOAuthStatusView {
 
 fn normalized_api_base(vendor: &str, auth_mode: AuthMode, configured: &str) -> String {
     let configured = configured.trim_end_matches('/');
+    if vendor.eq_ignore_ascii_case("zenmux") && configured.is_empty() {
+        return ZENMUX_DEFAULT_API_BASE_URL.to_string();
+    }
     if vendor == "openai" && matches!(auth_mode, AuthMode::OAuth) {
         if configured.is_empty() || configured == OPENAI_PLATFORM_BASE_URL {
             return OPENAI_CODEX_BASE_URL.to_string();
@@ -1826,6 +2135,20 @@ fn normalized_provider_metadata(
     metadata
 }
 
+fn validate_usage_management_key_request(
+    vendor: &str,
+    usage_management_key: Option<&str>,
+) -> Result<(), AdminError> {
+    if usage_management_key.is_some_and(|key| !key.trim().is_empty())
+        && !vendor.eq_ignore_ascii_case("zenmux")
+    {
+        return Err(AdminError::BadRequest(
+            "usage_management_key is only supported by the ZenMux provider".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 struct ListProvidersQuery {
     enabled: Option<bool>,
@@ -1868,6 +2191,7 @@ async fn create_provider(
         .unwrap_or(AuthMode::ApiKey);
     validate_provider_auth_mode(&req.vendor, auth_mode)
         .map_err(|message| AdminError::BadRequest(message.to_string()))?;
+    validate_usage_management_key_request(&req.vendor, req.usage_management_key.as_deref())?;
     let api_base = normalized_api_base(&req.vendor, auth_mode, &req.api_base);
     let models_endpoint = normalized_models_endpoint(
         &req.vendor,
@@ -1878,7 +2202,7 @@ async fn create_provider(
     let metadata = normalized_provider_metadata(&req.vendor, auth_mode, req.metadata);
     let p = state
         .store
-        .upsert_provider(
+        .upsert_provider_with_usage_management_key(
             &id,
             &req.name,
             &req.vendor,
@@ -1889,6 +2213,7 @@ async fn create_provider(
             req.oauth_meta.as_deref(),
             metadata,
             req.enabled.unwrap_or(true),
+            req.usage_management_key.as_deref(),
         )
         .await?;
     let snap = provider_snapshot(&p);
@@ -1916,6 +2241,7 @@ async fn update_provider(
         .unwrap_or(AuthMode::ApiKey);
     validate_provider_auth_mode(&req.vendor, auth_mode)
         .map_err(|message| AdminError::BadRequest(message.to_string()))?;
+    validate_usage_management_key_request(&req.vendor, req.usage_management_key.as_deref())?;
     let api_base = normalized_api_base(&req.vendor, auth_mode, &req.api_base);
     let models_endpoint = normalized_models_endpoint(
         &req.vendor,
@@ -1945,6 +2271,7 @@ async fn update_provider(
             let models_endpoint = models_endpoint.clone();
             let api_key = req.api_key.clone();
             let oauth_meta = req.oauth_meta.clone();
+            let usage_management_key = req.usage_management_key.clone();
             let metadata = metadata.clone();
             let enabled = req.enabled.unwrap_or(true);
             service
@@ -1953,7 +2280,7 @@ async fn update_provider(
                     Box::new(move || {
                         Box::pin(async move {
                             store
-                                .upsert_provider(
+                                .upsert_provider_with_usage_management_key(
                                     &mutation_id,
                                     &name,
                                     &vendor,
@@ -1964,6 +2291,7 @@ async fn update_provider(
                                     oauth_meta.as_deref(),
                                     metadata,
                                     enabled,
+                                    usage_management_key.as_deref(),
                                 )
                                 .await
                                 .map(|_| ())
@@ -1981,7 +2309,7 @@ async fn update_provider(
         } else {
             let provider = state
                 .store
-                .upsert_provider(
+                .upsert_provider_with_usage_management_key(
                     &id,
                     &req.name,
                     &req.vendor,
@@ -1992,6 +2320,7 @@ async fn update_provider(
                     req.oauth_meta.as_deref(),
                     metadata,
                     req.enabled.unwrap_or(true),
+                    req.usage_management_key.as_deref(),
                 )
                 .await?;
             state
@@ -2005,7 +2334,7 @@ async fn update_provider(
     } else {
         state
             .store
-            .upsert_provider(
+            .upsert_provider_with_usage_management_key(
                 &id,
                 &req.name,
                 &req.vendor,
@@ -2016,6 +2345,7 @@ async fn update_provider(
                 req.oauth_meta.as_deref(),
                 metadata,
                 req.enabled.unwrap_or(true),
+                req.usage_management_key.as_deref(),
             )
             .await?
     };
@@ -3477,6 +3807,7 @@ mod tests {
             api_base: api_base.to_string(),
             models_endpoint: models_endpoint.to_string(),
             encrypted_api_key: String::new(),
+            encrypted_usage_management_key: String::new(),
             auth_mode,
             encrypted_oauth_meta: String::new(),
             metadata_json: json!({}),
@@ -3484,6 +3815,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: None,
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: None,
         }
     }
@@ -3604,6 +3936,87 @@ mod tests {
         assert_eq!(
             seven_day.and_then(|window| window.reset_at),
             Some(1_000_600)
+        );
+    }
+
+    #[test]
+    fn parses_zenmux_subscription_tier_and_quota_windows() {
+        let body = json!({
+            "success": true,
+            "data": {
+                "plan": {"tier": "pro"},
+                "quota_5_hour": {
+                    "usage_percentage": 0.25,
+                    "resets_at": "2026-08-30T00:00:00Z"
+                },
+                "quota_7_day": {
+                    "usage_percentage": "10",
+                    "resets_at": "2026-09-01T00:00:00Z"
+                }
+            }
+        })
+        .to_string();
+
+        let parsed = parse_zenmux_usage(&body).expect("ZenMux usage JSON");
+        assert_eq!(parsed.plan_type.as_deref(), Some("pro"));
+        assert_eq!(parsed.windows.len(), 2);
+        assert_eq!(parsed.windows[0].used_percent, Some(25.0));
+        assert_eq!(
+            parsed.windows[0].limit_window_seconds,
+            Some(FIVE_HOURS_SECONDS)
+        );
+        assert_eq!(
+            parsed.windows[0].reset_at,
+            chrono::DateTime::parse_from_rfc3339("2026-08-30T00:00:00Z")
+                .ok()
+                .map(|timestamp| timestamp.timestamp())
+        );
+        assert_eq!(parsed.windows[1].used_percent, Some(10.0));
+        assert_eq!(
+            parsed.windows[1].limit_window_seconds,
+            Some(SEVEN_DAYS_SECONDS)
+        );
+    }
+
+    #[test]
+    fn derives_zenmux_usage_percentage_from_flow_counts() {
+        let body = json!({
+            "plan": "team",
+            "quota_5_hour": {
+                "max_flows": 200,
+                "used_flows": 30,
+                "resets_at": 1_800_000_000_i64
+            },
+            "quota_7_day": {
+                "max_flows": 100,
+                "remaining_flows": 40
+            }
+        })
+        .to_string();
+
+        let parsed = parse_zenmux_usage(&body).expect("ZenMux usage JSON");
+        assert_eq!(parsed.plan_type.as_deref(), Some("team"));
+        assert_eq!(parsed.windows[0].used_percent, Some(15.0));
+        assert_eq!(parsed.windows[1].used_percent, Some(60.0));
+    }
+
+    #[test]
+    fn builds_zenmux_management_usage_url_from_provider_api_base() {
+        let provider = |api_base: &str| Provider {
+            api_base: api_base.to_string(),
+            ..openai_provider(AuthMode::ApiKey, api_base, "")
+        };
+        assert_eq!(
+            zenmux_subscription_usage_url(&provider("https://zenmux.ai")),
+            Some("https://zenmux.ai/api/v1/management/subscription/detail".to_string())
+        );
+        assert_eq!(
+            zenmux_subscription_usage_url(&provider("https://zenmux.dev/api/v1/")),
+            Some("https://zenmux.dev/api/v1/management/subscription/detail".to_string())
+        );
+        assert_eq!(
+            zenmux_subscription_usage_url(&provider("")),
+            Some("https://zenmux.ai/api/v1/management/subscription/detail".to_string())
         );
     }
 
@@ -3885,6 +4298,7 @@ mod tests {
     fn provider_view_exposes_sanitized_invalid_oauth_status() {
         let mut provider = openai_provider(AuthMode::OAuth, OPENAI_CODEX_BASE_URL, "");
         provider.encrypted_oauth_meta = "encrypted-secret".to_string();
+        provider.encrypted_usage_management_key = "manage-secret".to_string();
         provider.oauth_meta_cleartext = Some(
             json!({
                 "refresh_token": "never-return-this",
@@ -3895,6 +4309,7 @@ mod tests {
             .to_string(),
         );
 
+        let audit = provider_snapshot(&provider);
         let view = ProviderView::from(provider);
         let status = view.oauth_status.as_ref().expect("OAuth status");
         assert_eq!(status.state, "invalid");
@@ -3902,6 +4317,10 @@ mod tests {
         assert_eq!(status.checked_at.as_deref(), Some("2026-07-12T06:00:00Z"));
         let serialized = serde_json::to_string(&view).expect("serialize provider view");
         assert!(!serialized.contains("never-return-this"));
+        assert!(audit["usage_management_key"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("[encrypted:")));
+        assert!(!audit.to_string().contains("manage-secret"));
     }
 
     #[derive(Default)]

--- a/crates/admin/tests/integration.rs
+++ b/crates/admin/tests/integration.rs
@@ -415,6 +415,90 @@ async fn acceptance_1_provider_secret_is_encrypted_at_rest() {
 }
 
 #[tokio::test]
+async fn zenmux_usage_uses_management_key_and_maps_subscription_data() {
+    let (router, _store, pool) = boot_no_auth().await;
+    let upstream = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path(
+            "/api/v1/management/subscription/detail",
+        ))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer manage-key-secret",
+        ))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "plan": {"tier": "pro"},
+                "quota_5_hour": {
+                    "usage_percentage": 0.25,
+                    "resets_at": "2026-08-30T00:00:00Z"
+                },
+                "quota_7_day": {
+                    "usage_percentage": 0.1,
+                    "resets_at": "2026-09-01T00:00:00Z"
+                }
+            }
+        })))
+        .mount(&upstream)
+        .await;
+
+    let create = router
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/admin/v1/providers",
+            json!({
+                "id": "zenmux-usage",
+                "name": "ZenMux",
+                "vendor": "zenmux",
+                "api_base": upstream.uri(),
+                "api_key": "upstream-key",
+                "usage_management_key": "manage-key-secret",
+            }),
+        ))
+        .await
+        .expect("create response");
+    assert_eq!(create.status(), StatusCode::CREATED);
+    let create_body = axum::body::to_bytes(create.into_body(), 8192)
+        .await
+        .expect("create body");
+    let create_json: serde_json::Value = serde_json::from_slice(&create_body).expect("create JSON");
+    assert!(create_json["encrypted_usage_management_key"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("[encrypted:")));
+    assert!(!create_json.to_string().contains("manage-key-secret"));
+
+    let usage = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/v1/providers/zenmux-usage/usage")
+                .body(Body::empty())
+                .expect("usage request"),
+        )
+        .await
+        .expect("usage response");
+    assert_eq!(usage.status(), StatusCode::OK);
+    let usage_body = axum::body::to_bytes(usage.into_body(), 8192)
+        .await
+        .expect("usage body");
+    let usage_json: serde_json::Value = serde_json::from_slice(&usage_body).expect("usage JSON");
+    assert_eq!(usage_json["state"], json!("available"));
+    assert_eq!(usage_json["plan_type"], json!("pro"));
+    assert_eq!(usage_json["five_hour"]["used_percent"], json!(25.0));
+    assert_eq!(usage_json["seven_day"]["used_percent"], json!(10.0));
+
+    let encrypted: String = sqlx::query_scalar(
+        "SELECT encrypted_usage_management_key FROM providers WHERE id = 'zenmux-usage'",
+    )
+    .fetch_one(pool.any())
+    .await
+    .expect("stored management key");
+    assert!(!encrypted.contains("manage-key-secret"));
+}
+
+#[tokio::test]
 async fn acceptance_1_with_master_key_decrypts_into_routing_table() {
     // Boot a DbConfigStore with a real AES-256-GCM master key.
     let pool = Arc::new(db::open_pool("sqlite::memory:").await.expect("pool"));

--- a/crates/server/tests/models_catalog.rs
+++ b/crates/server/tests/models_catalog.rs
@@ -114,6 +114,7 @@ async fn models_endpoint_prefers_persisted_route_metadata_over_catalog() {
         api_base: "https://api.openai.com/v1".to_string(),
         models_endpoint: String::new(),
         encrypted_api_key: String::new(),
+        encrypted_usage_management_key: String::new(),
         auth_mode: AuthMode::None,
         encrypted_oauth_meta: String::new(),
         metadata_json: json!({}),
@@ -121,6 +122,7 @@ async fn models_endpoint_prefers_persisted_route_metadata_over_catalog() {
         created_at: now,
         updated_at: now,
         api_key_cleartext: None,
+        usage_management_key_cleartext: None,
         oauth_meta_cleartext: None,
     };
     let route = Route {

--- a/crates/store/migrations/config/20260829000001_provider_usage_management_key.sql
+++ b/crates/store/migrations/config/20260829000001_provider_usage_management_key.sql
@@ -1,0 +1,5 @@
+-- Optional provider-specific secret used by the Admin API to query
+-- subscription usage. It is separate from the upstream API key because the
+-- ZenMux Management API key has a different scope and purpose.
+ALTER TABLE providers
+    ADD COLUMN encrypted_usage_management_key TEXT NOT NULL DEFAULT '';

--- a/crates/store/migrations/postgres/config/20260829000001_provider_usage_management_key.sql
+++ b/crates/store/migrations/postgres/config/20260829000001_provider_usage_management_key.sql
@@ -1,0 +1,5 @@
+-- Optional provider-specific secret used by the Admin API to query
+-- subscription usage. It is separate from the upstream API key because the
+-- ZenMux Management API key has a different scope and purpose.
+ALTER TABLE providers
+    ADD COLUMN encrypted_usage_management_key TEXT NOT NULL DEFAULT '';

--- a/crates/store/src/config_store.rs
+++ b/crates/store/src/config_store.rs
@@ -788,7 +788,7 @@ impl DbConfigStore {
     pub async fn get_provider(&self, id: &str) -> Result<Option<Provider>, StoreError> {
         let rows = sqlx::query(
             "SELECT id, name, vendor, api_base, models_endpoint, encrypted_api_key, auth_mode, \
-                    encrypted_oauth_meta, metadata_json, enabled, \
+                    encrypted_usage_management_key, encrypted_oauth_meta, metadata_json, enabled, \
                     created_at, updated_at FROM providers WHERE id = $1",
         )
         .bind(id)
@@ -797,6 +797,7 @@ impl DbConfigStore {
         let mut provider = rows.map(row_to_provider).transpose()?;
         if let Some(provider) = provider.as_mut() {
             populate_provider_oauth_cleartext(self.encryption.as_ref(), provider);
+            populate_provider_usage_management_key_cleartext(self.encryption.as_ref(), provider);
         }
         Ok(provider)
     }
@@ -811,7 +812,7 @@ impl DbConfigStore {
     ) -> Result<Option<Provider>, StoreError> {
         let row = sqlx::query(
             "SELECT id, name, vendor, api_base, models_endpoint, encrypted_api_key, auth_mode, \
-                    encrypted_oauth_meta, metadata_json, enabled, \
+                    encrypted_usage_management_key, encrypted_oauth_meta, metadata_json, enabled, \
                     created_at, updated_at FROM providers WHERE id = $1",
         )
         .bind(id)
@@ -820,6 +821,7 @@ impl DbConfigStore {
         let mut provider = row.map(row_to_provider).transpose()?;
         if let Some(provider) = provider.as_mut() {
             populate_provider_oauth_cleartext(self.encryption.as_ref(), provider);
+            populate_provider_usage_management_key_cleartext(self.encryption.as_ref(), provider);
         }
         Ok(provider)
     }
@@ -837,6 +839,41 @@ impl DbConfigStore {
         oauth_meta_plain: Option<&str>,
         metadata_json: serde_json::Value,
         enabled: bool,
+    ) -> Result<Provider, StoreError> {
+        self.upsert_provider_with_usage_management_key(
+            id,
+            name,
+            vendor,
+            api_base,
+            models_endpoint,
+            api_key_plain,
+            auth_mode,
+            oauth_meta_plain,
+            metadata_json,
+            enabled,
+            None,
+        )
+        .await
+    }
+
+    /// Upsert a provider and optionally replace its subscription-management
+    /// key. `None` preserves the existing key, while `Some("")` clears it.
+    /// The extra key is stored separately from the upstream API key because it
+    /// is used only for provider-specific Admin usage requests.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert_provider_with_usage_management_key(
+        &self,
+        id: &str,
+        name: &str,
+        vendor: &str,
+        api_base: &str,
+        models_endpoint: &str,
+        api_key_plain: Option<&str>,
+        auth_mode: AuthMode,
+        oauth_meta_plain: Option<&str>,
+        metadata_json: serde_json::Value,
+        enabled: bool,
+        usage_management_key_plain: Option<&str>,
     ) -> Result<Provider, StoreError> {
         validate_provider_auth_mode(vendor, auth_mode)
             .map_err(|message| StoreError::Invalid(message.to_string()))?;
@@ -866,6 +903,30 @@ impl DbConfigStore {
                 .map(|p| p.encrypted_oauth_meta.clone())
                 .unwrap_or_default(),
         };
+        let encrypted_usage_management_key = match (
+            usage_management_key_plain,
+            self.encryption.as_ref(),
+        ) {
+            (Some(plain), Some(enc)) => {
+                let plain = plain.trim();
+                if plain.is_empty() {
+                    String::new()
+                } else {
+                    keys::encrypt_usage_management_key(enc, plain)
+                        .map_err(|e| StoreError::Decrypt(e.to_string()))?
+                }
+            }
+            (Some(plain), None) => {
+                warn!(
+                    "TIYGATE_MASTER_KEY not set; storing usage management key in cleartext (NOT FOR PRODUCTION)"
+                );
+                plain.trim().to_string()
+            }
+            (None, _) => existing
+                .as_ref()
+                .map(|p| p.encrypted_usage_management_key.clone())
+                .unwrap_or_default(),
+        };
         let metadata_str = serde_json::to_string(&metadata_json)?;
         let enabled_int: i32 = if enabled { 1 } else { 0 };
         let created_at = existing
@@ -875,12 +936,13 @@ impl DbConfigStore {
 
         sqlx::query(
             "INSERT INTO providers (id, name, vendor, api_base, models_endpoint, encrypted_api_key, auth_mode, \
-             encrypted_oauth_meta, metadata_json, enabled, created_at, updated_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) \
+             encrypted_usage_management_key, encrypted_oauth_meta, metadata_json, enabled, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) \
              ON CONFLICT(id) DO UPDATE SET \
                 name=excluded.name, vendor=excluded.vendor, api_base=excluded.api_base, \
                 models_endpoint=excluded.models_endpoint, \
                 encrypted_api_key=excluded.encrypted_api_key, auth_mode=excluded.auth_mode, \
+                encrypted_usage_management_key=excluded.encrypted_usage_management_key, \
                 encrypted_oauth_meta=excluded.encrypted_oauth_meta, metadata_json=excluded.metadata_json, \
                 enabled=excluded.enabled, updated_at=excluded.updated_at",
         )
@@ -891,6 +953,7 @@ impl DbConfigStore {
         .bind(models_endpoint)
         .bind(&encrypted_api_key)
         .bind(auth_mode.as_str())
+        .bind(&encrypted_usage_management_key)
         .bind(&encrypted_oauth_meta)
         .bind(&metadata_str)
         .bind(enabled_int)
@@ -1147,7 +1210,7 @@ impl DbConfigStore {
     async fn load_providers(&self) -> Result<Vec<Provider>, StoreError> {
         let rows = sqlx::query(
             "SELECT id, name, vendor, api_base, models_endpoint, encrypted_api_key, auth_mode, \
-                    encrypted_oauth_meta, metadata_json, enabled, \
+                    encrypted_usage_management_key, encrypted_oauth_meta, metadata_json, enabled, \
                     created_at, updated_at FROM providers",
         )
         .fetch_all(self.pool.any())
@@ -1436,6 +1499,7 @@ impl DbConfigStore {
         // cannot leak the decrypted secret.
         for p in providers.iter_mut() {
             p.api_key_cleartext = None;
+            p.usage_management_key_cleartext = None;
         }
         let routes = self.load_routes().await?;
         let api_keys = self.list_api_keys().await?;
@@ -1575,6 +1639,22 @@ impl DbConfigStore {
                     None => plain,
                 }
             };
+            let enc_usage_management_key = if p.encrypted_usage_management_key.is_empty() {
+                String::new()
+            } else {
+                let plain = match &source_enc {
+                    Some(src) => {
+                        keys::decrypt_usage_management_key(src, &p.encrypted_usage_management_key)
+                            .map_err(|e| StoreError::Decrypt(e.to_string()))?
+                    }
+                    None => p.encrypted_usage_management_key.clone(),
+                };
+                match self.encryption.as_ref() {
+                    Some(enc) => keys::encrypt_usage_management_key(enc, &plain)
+                        .map_err(|e| StoreError::Decrypt(e.to_string()))?,
+                    None => plain,
+                }
+            };
             let metadata_str = serde_json::to_string(&p.metadata_json)?;
             let enabled_int: i32 = if p.enabled { 1 } else { 0 };
             let created_at = p.created_at.to_rfc3339();
@@ -1584,12 +1664,13 @@ impl DbConfigStore {
             // effect.
             sqlx::query(
                 "INSERT INTO providers (id, name, vendor, api_base, models_endpoint, encrypted_api_key, auth_mode, \
-                 encrypted_oauth_meta, metadata_json, enabled, created_at, updated_at) \
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) \
+                 encrypted_usage_management_key, encrypted_oauth_meta, metadata_json, enabled, created_at, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) \
                  ON CONFLICT(id) DO UPDATE SET \
                     name=excluded.name, vendor=excluded.vendor, api_base=excluded.api_base, \
                     models_endpoint=excluded.models_endpoint, \
                     encrypted_api_key=excluded.encrypted_api_key, auth_mode=excluded.auth_mode, \
+                    encrypted_usage_management_key=excluded.encrypted_usage_management_key, \
                     encrypted_oauth_meta=excluded.encrypted_oauth_meta, \
                     metadata_json=excluded.metadata_json, \
                     enabled=excluded.enabled, updated_at=excluded.updated_at",
@@ -1601,6 +1682,7 @@ impl DbConfigStore {
             .bind(&p.models_endpoint)
             .bind(&enc_api_key)
             .bind(p.auth_mode.as_str())
+            .bind(&enc_usage_management_key)
             .bind(&enc_oauth_meta)
             .bind(&metadata_str)
             .bind(enabled_int)
@@ -1933,12 +2015,14 @@ fn row_to_provider(row: sqlx::any::AnyRow) -> Result<Provider, StoreError> {
         models_endpoint: row.get("models_endpoint"),
         encrypted_api_key: row.get("encrypted_api_key"),
         auth_mode,
+        encrypted_usage_management_key: row.get("encrypted_usage_management_key"),
         encrypted_oauth_meta: row.get("encrypted_oauth_meta"),
         metadata_json,
         enabled: enabled_int != 0,
         created_at: parse_dt(row.get("created_at"))?,
         updated_at: parse_dt(row.get("updated_at"))?,
         api_key_cleartext: None,
+        usage_management_key_cleartext: None,
         oauth_meta_cleartext: None,
     })
 }
@@ -1969,6 +2053,33 @@ fn populate_provider_oauth_cleartext(
     } else {
         // No master key: column holds cleartext.
         provider.oauth_meta_cleartext = Some(provider.encrypted_oauth_meta.clone());
+    }
+}
+
+fn populate_provider_usage_management_key_cleartext(
+    encryption: Option<&Arc<KeyEncryption>>,
+    provider: &mut Provider,
+) {
+    if provider.encrypted_usage_management_key.is_empty() {
+        provider.usage_management_key_cleartext = Some(String::new());
+        return;
+    }
+    if let Some(enc) = encryption {
+        match keys::decrypt_usage_management_key(enc, &provider.encrypted_usage_management_key) {
+            Ok(plain) => provider.usage_management_key_cleartext = Some(plain),
+            Err(error) => {
+                tracing::warn!(
+                    provider = %provider.id,
+                    error = %error,
+                    "decrypting provider usage management key failed; Admin usage will be unavailable"
+                );
+                provider.usage_management_key_cleartext = None;
+            }
+        }
+    } else {
+        // No master key: the column holds cleartext.
+        provider.usage_management_key_cleartext =
+            Some(provider.encrypted_usage_management_key.clone());
     }
 }
 
@@ -2108,6 +2219,7 @@ mod tests {
             api_base: "https://example.test/root".to_string(),
             models_endpoint: String::new(),
             encrypted_api_key: "sk-test".to_string(),
+            encrypted_usage_management_key: String::new(),
             auth_mode: AuthMode::ApiKey,
             encrypted_oauth_meta: String::new(),
             metadata_json: serde_json::json!({}),
@@ -2115,6 +2227,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: Some("sk-test".to_string()),
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: None,
         };
         let route = Route {
@@ -2164,6 +2277,7 @@ mod tests {
             api_base: "https://api.openai.com/v1".to_string(),
             models_endpoint: String::new(),
             encrypted_api_key: "sk-test".to_string(),
+            encrypted_usage_management_key: String::new(),
             auth_mode: AuthMode::ApiKey,
             encrypted_oauth_meta: String::new(),
             metadata_json: serde_json::json!({}),
@@ -2171,6 +2285,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: Some("sk-test".to_string()),
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: None,
         };
         // Two targets: one enabled, one disabled.
@@ -2234,6 +2349,7 @@ mod tests {
             api_base: "https://api.openai.com/v1".to_string(),
             models_endpoint: String::new(),
             encrypted_api_key: "sk-test".to_string(),
+            encrypted_usage_management_key: String::new(),
             auth_mode: AuthMode::ApiKey,
             encrypted_oauth_meta: String::new(),
             metadata_json: serde_json::json!({}),
@@ -2241,6 +2357,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: Some("sk-test".to_string()),
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: None,
         };
         let route = Route {
@@ -2375,6 +2492,48 @@ mod tests {
             provider_in_tx.oauth_meta_cleartext.as_deref(),
             Some(meta_str.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn usage_management_key_is_encrypted_and_available_for_direct_reads() {
+        let key = KeyEncryption::from_secret(&master_key_hex()).expect("key");
+        let store = boot_store(Some(Arc::new(key))).await;
+        store
+            .upsert_provider_with_usage_management_key(
+                "zenmux-usage",
+                "ZenMux",
+                "zenmux",
+                "https://zenmux.ai/api",
+                "",
+                Some("upstream-key"),
+                AuthMode::ApiKey,
+                None,
+                serde_json::json!({}),
+                true,
+                Some("manage-key-secret"),
+            )
+            .await
+            .expect("upsert ZenMux provider");
+
+        let encrypted: String = sqlx::query_scalar(
+            "SELECT encrypted_usage_management_key FROM providers WHERE id = 'zenmux-usage'",
+        )
+        .fetch_one(store.pool.any())
+        .await
+        .expect("usage management key");
+        assert!(!encrypted.contains("manage-key-secret"));
+        assert!(encrypted.len() > 20);
+
+        let provider = store
+            .get_provider("zenmux-usage")
+            .await
+            .expect("get provider")
+            .expect("provider exists");
+        assert_eq!(
+            provider.usage_management_key_cleartext.as_deref(),
+            Some("manage-key-secret")
+        );
+        assert_eq!(provider.encrypted_usage_management_key, encrypted);
     }
 
     #[tokio::test]
@@ -2516,6 +2675,7 @@ mod tests {
             api_base: OPENAI_PLATFORM_BASE_URL.to_string(),
             models_endpoint: String::new(),
             encrypted_api_key: String::new(),
+            encrypted_usage_management_key: String::new(),
             auth_mode: AuthMode::OAuth,
             encrypted_oauth_meta: String::new(),
             metadata_json: serde_json::json!({
@@ -2529,6 +2689,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: None,
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: Some(
                 serde_json::json!({
                     "refresh_token": "refresh",
@@ -2565,6 +2726,7 @@ mod tests {
             api_base: "https://api.anthropic.com".to_string(),
             models_endpoint: String::new(),
             encrypted_api_key: String::new(),
+            encrypted_usage_management_key: String::new(),
             auth_mode: AuthMode::OAuth,
             encrypted_oauth_meta: String::new(),
             metadata_json: serde_json::json!({
@@ -2577,6 +2739,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: None,
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: Some(serde_json::json!({"refresh_token": "refresh"}).to_string()),
         };
 
@@ -2595,6 +2758,7 @@ mod tests {
             api_base: "https://api.x.ai/v1".to_string(),
             models_endpoint: String::new(),
             encrypted_api_key: String::new(),
+            encrypted_usage_management_key: String::new(),
             auth_mode: AuthMode::OAuth,
             encrypted_oauth_meta: String::new(),
             metadata_json: serde_json::json!({
@@ -2607,6 +2771,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             api_key_cleartext: None,
+            usage_management_key_cleartext: None,
             oauth_meta_cleartext: Some(serde_json::json!({"refresh_token": "refresh"}).to_string()),
         };
 
@@ -2936,6 +3101,7 @@ mod tests {
                     api_base: "https://api.openai.com/v1".into(),
                     models_endpoint: String::new(),
                     encrypted_api_key: "sk-exported".into(),
+                    encrypted_usage_management_key: String::new(),
                     auth_mode: AuthMode::ApiKey,
                     encrypted_oauth_meta: String::new(),
                     metadata_json: serde_json::json!({}),
@@ -2943,6 +3109,7 @@ mod tests {
                     created_at: now,
                     updated_at: now,
                     api_key_cleartext: None,
+                    usage_management_key_cleartext: None,
                     oauth_meta_cleartext: None,
                 },
                 Provider {
@@ -2952,6 +3119,7 @@ mod tests {
                     api_base: "https://api.anthropic.com".into(),
                     models_endpoint: String::new(),
                     encrypted_api_key: "sk-new".into(),
+                    encrypted_usage_management_key: String::new(),
                     auth_mode: AuthMode::ApiKey,
                     encrypted_oauth_meta: String::new(),
                     metadata_json: serde_json::json!({}),
@@ -2959,6 +3127,7 @@ mod tests {
                     created_at: now,
                     updated_at: now,
                     api_key_cleartext: None,
+                    usage_management_key_cleartext: None,
                     oauth_meta_cleartext: None,
                 },
             ],
@@ -3223,6 +3392,7 @@ mod tests {
                 api_base: "https://api.openai.com/v1".into(),
                 models_endpoint: String::new(),
                 encrypted_api_key: "sk-new".into(),
+                encrypted_usage_management_key: String::new(),
                 auth_mode: AuthMode::ApiKey,
                 encrypted_oauth_meta: String::new(),
                 metadata_json: serde_json::json!({}),
@@ -3230,6 +3400,7 @@ mod tests {
                 created_at: now,
                 updated_at: now,
                 api_key_cleartext: None,
+                usage_management_key_cleartext: None,
                 oauth_meta_cleartext: None,
             }],
             routes: vec![],
@@ -3273,6 +3444,7 @@ mod tests {
                 api_base: "https://api.openai.com/v1".into(),
                 models_endpoint: String::new(),
                 encrypted_api_key: "sk-x".into(),
+                encrypted_usage_management_key: String::new(),
                 auth_mode: AuthMode::ApiKey,
                 encrypted_oauth_meta: String::new(),
                 metadata_json: serde_json::json!({}),
@@ -3280,6 +3452,7 @@ mod tests {
                 created_at: now,
                 updated_at: now,
                 api_key_cleartext: None,
+                usage_management_key_cleartext: None,
                 oauth_meta_cleartext: None,
             }],
             routes: vec![],

--- a/crates/store/src/keys.rs
+++ b/crates/store/src/keys.rs
@@ -1,10 +1,10 @@
 //! Higher-level wrappers around [`crate::encryption::KeyEncryption`].
 //!
 //! These are the functions the rest of the gateway uses to encrypt
-//! and decrypt provider API keys. They are deliberately tiny so the
+//! and decrypt provider credentials. They are deliberately tiny so the
 //! auth-mode branching lives in one place and so that switching
-//! purposes (provider API key vs. OAuth refresh token) does not
-//! require changes in any other file.
+//! purposes (provider API key, management key, or OAuth refresh token)
+//! does not require changes in any other file.
 
 use crate::encryption::{EncryptionError, KeyEncryption};
 
@@ -12,6 +12,10 @@ use crate::encryption::{EncryptionError, KeyEncryption};
 /// API key. Distinct from the OAuth purpose so an operator can
 /// rotate one without invalidating the other.
 pub const PURPOSE_PROVIDER_API_KEY: &str = "provider-api-key";
+/// Purpose label used to derive the subkey for an optional provider
+/// subscription-management key. This must remain distinct from the
+/// upstream API key because the two credentials have different scopes.
+pub const PURPOSE_USAGE_MANAGEMENT_KEY: &str = "usage-management-key";
 /// Purpose label used to derive the subkey for OAuth refresh tokens.
 pub const PURPOSE_OAUTH_REFRESH_TOKEN: &str = "oauth-refresh-token";
 /// Purpose label used for short-lived OAuth access tokens cached in the
@@ -31,6 +35,22 @@ pub fn encrypt_api_key(enc: &KeyEncryption, api_key: &str) -> Result<String, Enc
 /// Decrypt a provider API key.
 pub fn decrypt_api_key(enc: &KeyEncryption, blob: &str) -> Result<String, EncryptionError> {
     enc.decrypt(PURPOSE_PROVIDER_API_KEY, blob)
+}
+
+/// Encrypt a provider subscription-management key.
+pub fn encrypt_usage_management_key(
+    enc: &KeyEncryption,
+    key: &str,
+) -> Result<String, EncryptionError> {
+    enc.encrypt(PURPOSE_USAGE_MANAGEMENT_KEY, key)
+}
+
+/// Decrypt a provider subscription-management key.
+pub fn decrypt_usage_management_key(
+    enc: &KeyEncryption,
+    blob: &str,
+) -> Result<String, EncryptionError> {
+    enc.decrypt(PURPOSE_USAGE_MANAGEMENT_KEY, blob)
 }
 
 /// Encrypt an OAuth refresh token JSON blob.
@@ -114,5 +134,12 @@ mod tests {
             "access-token"
         );
         assert!(decrypt_oauth_meta(&e, &access).is_err());
+
+        let usage = encrypt_usage_management_key(&e, "manage-key").unwrap();
+        assert_eq!(
+            decrypt_usage_management_key(&e, &usage).unwrap(),
+            "manage-key"
+        );
+        assert!(decrypt_api_key(&e, &usage).is_err());
     }
 }

--- a/crates/store/src/models.rs
+++ b/crates/store/src/models.rs
@@ -78,6 +78,10 @@ pub struct Provider {
     /// Encrypted API key (or empty). Set at upsert time; the
     /// `DbConfigStore` populates `api_key_cleartext` on read.
     pub encrypted_api_key: String,
+    /// Optional encrypted provider-management key used for subscription
+    /// usage queries (or empty). It is never used for upstream inference.
+    #[serde(default)]
+    pub encrypted_usage_management_key: String,
     pub auth_mode: AuthMode,
     /// Encrypted OAuth metadata JSON, or empty.
     pub encrypted_oauth_meta: String,
@@ -93,6 +97,11 @@ pub struct Provider {
     /// and the cleartext lives in `encrypted_api_key` verbatim).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key_cleartext: Option<String>,
+    /// Decrypted cleartext of `encrypted_usage_management_key`. Populated
+    /// only for direct provider reads that need to make an Admin usage
+    /// request; the regular data-plane snapshot leaves this unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage_management_key_cleartext: Option<String>,
     /// Decrypted cleartext of `encrypted_oauth_meta`. Populated by
     /// `DbConfigStore::refresh()` for OAuth-mode providers so
     /// `snapshot_to_routing_table` can extract the refresh token
@@ -282,7 +291,8 @@ pub struct ConfigExport {
     /// RFC-3339 timestamp of when the export was produced.
     pub exported_at: String,
     /// Whether the source instance had a master key configured. When
-    /// `true`, provider `encrypted_api_key` / `encrypted_oauth_meta`
+    /// `true`, provider `encrypted_api_key` / `encrypted_oauth_meta` /
+    /// `encrypted_usage_management_key`
     /// are real AES-GCM blobs that need the source master key to
     /// decrypt. When `false`, those columns hold cleartext.
     pub encrypted: bool,

--- a/docs/deployment-operations.md
+++ b/docs/deployment-operations.md
@@ -66,7 +66,7 @@ Settings 页面分为五个卡片:
 | **后台任务** | 日志保留间隔与天数、epoch 轮询间隔、token 统计间隔与回看天数 | `TIYGATE_LOG_RETENTION_*`、`TIYGATE_EPOCH_POLL_INTERVAL_SECS`、`TIYGATE_TOKEN_STATS_*` |
 
 - **epoch 版本号**:数据面轮询配置变更,原子切换到新快照;**在途请求保持旧 epoch 直到结束**——不会看到半新半旧配置。
-- **密钥加密**:provider key / OAuth token / 加密的 S3 设置在数据库中 AES-GCM 静态加密,主密钥来自 `TIYGATE_MASTER_KEY`。加密设置在 `GET /admin/v1/settings` 时脱敏返回。
+- **密钥加密**: provider key、OAuth token、ZenMux 用量管理 key 和加密的 S3 设置在数据库中 AES-GCM 静态加密,主密钥来自 `TIYGATE_MASTER_KEY`。加密设置在 `GET /admin/v1/settings` 时脱敏返回。
 
 ### 缓存
 

--- a/docs/oauth-token-lifecycle.md
+++ b/docs/oauth-token-lifecycle.md
@@ -116,6 +116,15 @@ so equal-duration weekly limits remain distinguishable. Null or non-applicable
 windows are omitted, and the WebUI keeps successful usage results fresh for 60
 seconds to avoid repeatedly probing the upstream endpoint during navigation.
 
+ZenMux providers can optionally store a separate encrypted usage management
+key. When present, the Admin provider list requests the subscription detail
+endpoint at /api/v1/management/subscription/detail from the configured ZenMux
+API base with that key as a Bearer credential. The response's plan tier and
+5-hour and 7-day quota fields are normalized into the same plan badge and
+usage-window meters used by OpenAI OAuth. ZenMux's usage percentage ratio
+(0..1) is converted to the Admin usage percentage (0..100); the management key
+is never used for inference requests or returned in cleartext.
+
 ## Background keepalive
 
 Every instance scans due OAuth providers. A scan does not elect a permanent

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -9,6 +9,7 @@ export interface Provider {
   models_endpoint: string;
   auth_mode: string;
   encrypted_api_key: string;
+  encrypted_usage_management_key?: string;
   encrypted_oauth_meta: string;
   oauth_status?: {
     state: "not_connected" | "connected" | "healthy" | "invalid" | "error";
@@ -28,6 +29,7 @@ export interface ProviderInput {
   api_base: string;
   models_endpoint?: string;
   api_key?: string;
+  usage_management_key?: string;
   auth_mode?: string;
   oauth_meta?: string;
   metadata?: Record<string, unknown>;
@@ -430,6 +432,7 @@ export interface ExportProvider {
   api_base: string;
   models_endpoint: string;
   encrypted_api_key: string;
+  encrypted_usage_management_key?: string;
   auth_mode: string;
   encrypted_oauth_meta: string;
   metadata_json: Record<string, unknown>;

--- a/webui/src/i18n/locales/en.ts
+++ b/webui/src/i18n/locales/en.ts
@@ -255,6 +255,9 @@ const en = {
     },
     apiKey: "API key",
     apiKeyHint: "Leave blank to keep the existing secret.",
+    usageManagementKey: "Usage management key",
+    usageManagementKeyHint:
+      "Leave blank to keep the existing usage management key.",
     redacted: "Secret is stored encrypted and never returned.",
     deleteConfirm: "Delete provider {{name}}? This cannot be undone.",
     deleteImpactLoading: "Checking linked routes…",

--- a/webui/src/i18n/locales/zh.ts
+++ b/webui/src/i18n/locales/zh.ts
@@ -247,6 +247,8 @@ const zh: Translation = {
     },
     apiKey: "API 密钥",
     apiKeyHint: "留空则保留现有密钥。",
+    usageManagementKey: "用量管理 Key",
+    usageManagementKeyHint: "留空则保留现有用量管理 Key。",
     redacted: "密钥加密存储，永不返回明文。",
     deleteConfirm: "删除供应商 {{name}}？此操作不可撤销。",
     deleteImpactLoading: "正在检查关联路由…",

--- a/webui/src/pages/Providers.tsx
+++ b/webui/src/pages/Providers.tsx
@@ -1181,7 +1181,7 @@ export default function Providers() {
                       </div>
                     </Td>
                     <Td className="align-middle">
-                      {!isOAuthProvider(p) ? (
+                      {!isOAuthProvider(p) && !supportsProviderUsage(p) ? (
                         <div
                           className="truncate font-mono text-xs"
                           title={p.api_base}

--- a/webui/src/pages/Providers.tsx
+++ b/webui/src/pages/Providers.tsx
@@ -110,6 +110,7 @@ interface FormState {
   api_base: string;
   models_endpoint: string;
   api_key: string;
+  usage_management_key: string;
   auth_mode: string;
   enabled: boolean;
 }
@@ -128,6 +129,7 @@ function emptyForm(): FormState {
     api_base: "",
     models_endpoint: "",
     api_key: "",
+    usage_management_key: "",
     auth_mode: "api_key",
     enabled: true,
   };
@@ -163,6 +165,17 @@ function supportsOAuthUsage(provider: Provider): boolean {
   return (
     provider.auth_mode === "oauth" &&
     (provider.vendor === "openai" || provider.vendor === "anthropic")
+  );
+}
+
+function hasUsageManagementKey(provider: Provider): boolean {
+  return (provider.encrypted_usage_management_key?.trim() ?? "") !== "";
+}
+
+function supportsProviderUsage(provider: Provider): boolean {
+  return (
+    supportsOAuthUsage(provider) ||
+    (provider.vendor === "zenmux" && hasUsageManagementKey(provider))
   );
 }
 
@@ -529,7 +542,7 @@ function UsageWindowSummary({
   );
 }
 
-function OpenAiUsageLayout({
+function SubscriptionUsageLayout({
   providerId,
   usage,
   loading,
@@ -714,7 +727,7 @@ export default function Providers() {
     queries: (data ?? []).map((provider) => ({
       queryKey: ["provider-usage", provider.id],
       queryFn: () => providersApi.usage(provider.id),
-      enabled: supportsOAuthUsage(provider),
+      enabled: supportsProviderUsage(provider),
       staleTime: 60_000,
       retry: false,
     })),
@@ -933,6 +946,7 @@ export default function Providers() {
       api_base: p.api_base,
       models_endpoint: p.models_endpoint,
       api_key: "",
+      usage_management_key: "",
       auth_mode: p.auth_mode,
       enabled: p.enabled,
     });
@@ -1002,6 +1016,11 @@ export default function Providers() {
     // Only send api_key when the operator typed one — blank keeps the
     // existing encrypted secret untouched.
     if (form.api_key.trim()) body.api_key = form.api_key.trim();
+    // The ZenMux Management API key is independent from the upstream API
+    // key. Blank keeps the existing encrypted management key untouched.
+    if (form.usage_management_key.trim()) {
+      body.usage_management_key = form.usage_management_key.trim();
+    }
 
     // For OAuth providers, embed the OAuth preset metadata so the
     // backend's snapshot_to_routing_table can build OAuthTargetConfig
@@ -1170,12 +1189,14 @@ export default function Providers() {
                           {p.api_base}
                         </div>
                       ) : null}
-                      {supportsOAuthUsage(p) ? (
+                      {supportsProviderUsage(p) ? (
                         <div
                           className={cn(
                             "mt-1.5 min-w-[16rem]",
-                            p.vendor === "openai" && "min-w-[18rem]",
+                            (p.vendor === "openai" || p.vendor === "zenmux") &&
+                              "min-w-[18rem]",
                             p.vendor !== "openai" &&
+                              p.vendor !== "zenmux" &&
                               "grid grid-cols-2 gap-x-3 gap-y-1",
                           )}
                         >
@@ -1186,9 +1207,9 @@ export default function Providers() {
                             const windows = providerUsageWindows(usage);
                             const visibleWindows =
                               windows.length > 0 ? windows : [undefined];
-                            if (p.vendor === "openai") {
+                            if (p.vendor === "openai" || p.vendor === "zenmux") {
                               return (
-                                <OpenAiUsageLayout
+                                <SubscriptionUsageLayout
                                   providerId={p.id}
                                   usage={usage}
                                   loading={usageQuery?.isFetching ?? true}
@@ -1577,6 +1598,26 @@ export default function Providers() {
                 onChange={(e) => setForm({ ...form, api_key: e.target.value })}
                 placeholder={editing ? "••••••••" : "sk-…"}
                 toggleLabel={t("providers.apiKey")}
+                autoComplete="off"
+              />
+            </Field>
+          ) : null}
+          {form.vendor === "zenmux" ? (
+            <Field
+              label={t("providers.usageManagementKey")}
+              hint={
+                editing
+                  ? t("providers.usageManagementKeyHint")
+                  : t("providers.redacted")
+              }
+            >
+              <PasswordInput
+                value={form.usage_management_key}
+                onChange={(e) =>
+                  setForm({ ...form, usage_management_key: e.target.value })
+                }
+                placeholder={editing ? "••••••••" : "zm-…"}
+                toggleLabel={t("providers.usageManagementKey")}
                 autoComplete="off"
               />
             </Field>

--- a/webui/src/pages/Providers.tsx
+++ b/webui/src/pages/Providers.tsx
@@ -584,7 +584,7 @@ function SubscriptionUsageLayout({
   const firstUsed = usageWindowPercent(ringWindows[0]);
   const secondUsed = usageWindowPercent(ringWindows[1]);
   return (
-    <div className="flex min-w-0 items-center gap-4">
+    <div className="flex w-fit min-w-0 shrink-0 items-center gap-4">
       <div className="relative grid h-11 w-11 shrink-0 place-items-center">
         <svg
           viewBox="0 0 80 80"
@@ -681,11 +681,13 @@ function SubscriptionUsageLayout({
           </Badge>
         ) : null}
       </div>
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 shrink-0">
         <div
           className={cn(
-            "grid min-w-0 gap-y-2",
-            hasMultipleWindows ? "grid-cols-2 gap-x-4" : "grid-cols-1",
+            "grid w-fit min-w-0 gap-y-2",
+            hasMultipleWindows
+              ? "grid-flow-col auto-cols-max gap-x-4"
+              : "grid-cols-1",
           )}
         >
           {windows.map((window, index) => (
@@ -1114,7 +1116,7 @@ export default function Providers() {
               <colgroup>
                 <col style={{ width: "20rem" }} />
                 <col style={{ width: "16%" }} />
-                <col />
+                <col style={{ width: "24rem" }} />
                 <col style={{ width: "6rem" }} />
                 <col style={{ width: "6rem" }} />
                 <col style={{ width: "9rem" }} />
@@ -1132,7 +1134,7 @@ export default function Providers() {
                     {t("common.name")}
                   </Th>
                   <Th>{t("providers.vendor")}</Th>
-                  <Th>{t("providers.apiBase")}</Th>
+                  <Th className="min-w-[24rem]">{t("providers.apiBase")}</Th>
                   <Th>{t("providers.authMode")}</Th>
                   <Th className="text-center">{t("common.status")}</Th>
                   <Th>{t("common.updatedAt")}</Th>
@@ -1180,7 +1182,7 @@ export default function Providers() {
                         </span>
                       </div>
                     </Td>
-                    <Td className="align-middle">
+                    <Td className="min-w-[24rem] align-middle">
                       {!isOAuthProvider(p) && !supportsProviderUsage(p) ? (
                         <div
                           className="truncate font-mono text-xs"


### PR DESCRIPTION
## Summary

- Add provider usage-management key configuration and encrypted storage support
- Expose usage-management settings through the Admin API and provider model catalog
- Update provider management UI, API types, and English/Chinese translations
- Document usage-management key deployment and OAuth token lifecycle behavior
- Extend admin and model-catalog integration coverage

## Testing

- Added/updated admin integration and server model-catalog tests
- Not run (not requested)