### PR TITLE
feat(webui): ✨ Add page refresh controls

### DIFF
--- a/webui/src/components/PageHeader.tsx
+++ b/webui/src/components/PageHeader.tsx
@@ -1,18 +1,56 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { RefreshCw } from "lucide-react";
 
 export function PageHeader({
   title,
   description,
   action,
+  onRefresh,
 }: {
   title: string;
   description?: ReactNode;
   action?: ReactNode;
+  onRefresh?: () => void | Promise<unknown>;
 }) {
+  const { t } = useTranslation();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  async function handleRefresh() {
+    if (!onRefresh || isRefreshing) return;
+    setIsRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
+
+  const refreshLabel = t("common.refresh");
+
   return (
     <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
-        <h1 className="text-title-lg text-text">{title}</h1>
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="min-w-0 text-title-lg text-text">{title}</h1>
+          {onRefresh ? (
+            <button
+              type="button"
+              aria-label={refreshLabel}
+              aria-busy={isRefreshing || undefined}
+              title={refreshLabel}
+              disabled={isRefreshing}
+              onClick={() => void handleRefresh()}
+              className="inline-flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-surface text-text-muted transition-[background-color,border-color,color,transform] duration-[var(--duration-fast)] hover:border-border-strong hover:bg-surface-muted hover:text-text active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <RefreshCw
+                size={17}
+                aria-hidden
+                className={isRefreshing ? "animate-spin" : undefined}
+              />
+            </button>
+          ) : null}
+        </div>
         {description ? (
           <p className="mt-1 text-sm text-text-muted">{description}</p>
         ) : null}

--- a/webui/src/components/PageHeader.tsx
+++ b/webui/src/components/PageHeader.tsx
@@ -41,10 +41,10 @@ export function PageHeader({
               title={refreshLabel}
               disabled={isRefreshing}
               onClick={() => void handleRefresh()}
-              className="inline-flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-surface text-text-muted transition-[background-color,border-color,color,transform] duration-[var(--duration-fast)] hover:border-border-strong hover:bg-surface-muted hover:text-text active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-text-subtle transition-[color,transform,opacity] duration-[var(--duration-fast)] hover:text-text-muted active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50"
             >
               <RefreshCw
-                size={17}
+                size={14}
                 aria-hidden
                 className={isRefreshing ? "animate-spin" : undefined}
               />

--- a/webui/src/pages/ApiKeys.tsx
+++ b/webui/src/pages/ApiKeys.tsx
@@ -185,6 +185,11 @@ export default function ApiKeys() {
     queryFn: listAllVirtualModels,
   });
   const availableModels = routesQuery.data ?? [];
+
+  async function refreshPage() {
+    await Promise.all([refetch(), routesQuery.refetch()]);
+  }
+
   const { scrollRef, scrollState } = useStickyTableScroll([
     isLoading,
     data?.length ?? 0,
@@ -349,6 +354,7 @@ export default function ApiKeys() {
     <div>
       <PageHeader
         title={t("apiKeys.title")}
+        onRefresh={refreshPage}
         action={
           <Button
             variant="primary"

--- a/webui/src/pages/Audit.tsx
+++ b/webui/src/pages/Audit.tsx
@@ -184,7 +184,7 @@ export default function Audit() {
 
   return (
     <div className="space-y-4">
-      <PageHeader title={t("audit.title")} />
+      <PageHeader title={t("audit.title")} onRefresh={() => refetch()} />
       {error ? (
         <ErrorBox
           message={(error as Error).message}

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -305,9 +305,27 @@ export default function Dashboard() {
   const targets = breakers.data?.targets ?? [];
   const unhealthy = targets.filter((b) => !b.healthy).length;
 
+  async function refreshPage() {
+    await Promise.all([
+      byModel.refetch(),
+      byProvider.refetch(),
+      byApiKey.refetch(),
+      byTarget.refetch(),
+      breakers.refetch(),
+      tokenActivity.refetch(),
+      tokenSummary.refetch(),
+      providers.refetch(),
+      apiKeys.refetch(),
+    ]);
+  }
+
   return (
     <div className="space-y-6">
-      <PageHeader title={t("dashboard.title")} action={<InstanceIndicator />} />
+      <PageHeader
+        title={t("dashboard.title")}
+        onRefresh={refreshPage}
+        action={<InstanceIndicator />}
+      />
 
       {/* 1. Token Activity Heatmap + Summary cards — side by side */}
       <div className="flex flex-col xl:flex-row gap-4 xl:items-stretch">

--- a/webui/src/pages/Providers.tsx
+++ b/webui/src/pages/Providers.tsx
@@ -721,6 +721,7 @@ export default function Providers() {
     data: catalog,
     isLoading: catalogLoading,
     isError: catalogError,
+    refetch: refetchCatalog,
   } = useQuery({
     queryKey: ["provider-catalog"],
     queryFn: providerCatalogApi.list,
@@ -752,6 +753,17 @@ export default function Providers() {
     }
     return result;
   }, [data, usageQueries]);
+
+  async function refreshPage() {
+    const usageRefetches = usageQueries.flatMap((query, index) => {
+      const provider = data?.[index];
+      return provider && supportsProviderUsage(provider)
+        ? [query.refetch()]
+        : [];
+    });
+    await Promise.all([refetch(), refetchCatalog(), ...usageRefetches]);
+  }
+
   const [modalOpen, setModalOpen] = useState(false);
   const [form, setForm] = useState<FormState>(emptyForm());
   const [editing, setEditing] = useState<Provider | null>(null);
@@ -1070,6 +1082,7 @@ export default function Providers() {
     <div>
       <PageHeader
         title={t("providers.title")}
+        onRefresh={refreshPage}
         action={
           <Button
             variant="primary"

--- a/webui/src/pages/RequestLogs.tsx
+++ b/webui/src/pages/RequestLogs.tsx
@@ -285,7 +285,10 @@ export default function RequestLogs() {
     () => ({ since: filter.since, until: filter.until }),
     [filter.since, filter.until],
   );
-  const { data: filterOptionsData } = useQuery({
+  const {
+    data: filterOptionsData,
+    refetch: refetchFilterOptions,
+  } = useQuery({
     queryKey: ["request-filter-options", filterOptionsRange],
     queryFn: () => requestsApi.filterOptions(filterOptionsRange),
     staleTime: 5 * 60_000,
@@ -302,7 +305,7 @@ export default function RequestLogs() {
   // Provider directory: lets us render the upstream column with provider
   // name (e.g. "OpenAI Production") instead of a raw id. Long stale time
   // since names rarely change.
-  const { data: providers } = useQuery<Provider[]>({
+  const { data: providers, refetch: refetchProviders } = useQuery<Provider[]>({
     queryKey: ["providers"],
     queryFn: providersApi.list,
     staleTime: 5 * 60_000,
@@ -356,7 +359,7 @@ export default function RequestLogs() {
     [providerNameById],
   );
 
-  const { data: apiKeys } = useQuery<ApiKey[]>({
+  const { data: apiKeys, refetch: refetchApiKeys } = useQuery<ApiKey[]>({
     queryKey: ["api-keys"],
     queryFn: apiKeysApi.list,
     staleTime: 5 * 60_000,
@@ -376,6 +379,17 @@ export default function RequestLogs() {
     queryFn: () => requestsApi.replay(detail!.request_id),
     enabled: detail !== null,
   });
+
+  async function refreshPage() {
+    const refetches: Array<Promise<unknown>> = [
+      refetch(),
+      refetchFilterOptions(),
+      refetchProviders(),
+      refetchApiKeys(),
+    ];
+    if (detail !== null) refetches.push(replayQuery.refetch());
+    await Promise.all(refetches);
+  }
 
   const total = data?.total ?? 0;
   const offset = filter.offset ?? 0;
@@ -432,7 +446,7 @@ export default function RequestLogs() {
 
   return (
     <div className="space-y-4">
-      <PageHeader title={t("requests.title")} />
+      <PageHeader title={t("requests.title")} onRefresh={refreshPage} />
 
       <Card>
         <CardBody>

--- a/webui/src/pages/Routes.tsx
+++ b/webui/src/pages/Routes.tsx
@@ -190,7 +190,7 @@ export default function RoutesPage() {
     queryKey: ["routes", filter],
     queryFn: () => routesApi.list(filter),
   });
-  const { data: providers } = useQuery({
+  const { data: providers, refetch: refetchProviders } = useQuery({
     queryKey: ["providers"],
     queryFn: providersApi.list,
   });
@@ -690,10 +690,15 @@ export default function RoutesPage() {
 
   const routes = data?.entries ?? [];
 
+  async function refreshPage() {
+    await Promise.all([refetch(), refetchProviders()]);
+  }
+
   return (
     <div>
       <PageHeader
         title={t("routes.title")}
+        onRefresh={refreshPage}
         action={
           <Button
             variant="primary"


### PR DESCRIPTION
## Summary
- Add a reusable refresh icon beside page titles with accessible labeling and loading feedback.
- Refresh dashboard metrics and the current data plus supporting queries on each list page.

## Test Plan
- [x] npm run lint
- [x] npm run build
- [x] git diff --check

🤖 Generated with [Codex](https://github.com/codex)