### PR TITLE
fix(stats): 🐛 Make token dashboard stats atomic

### DIFF
--- a/crates/admin/src/handlers.rs
+++ b/crates/admin/src/handlers.rs
@@ -115,6 +115,10 @@ pub fn router() -> Router<AdminState> {
         .route("/admin/v1/stats/by-provider", get(stats_by_provider))
         .route("/admin/v1/stats/by-api-key", get(stats_by_api_key))
         .route("/admin/v1/stats/by-target", get(stats_by_target))
+        .route(
+            "/admin/v1/stats/token-dashboard",
+            get(stats_token_dashboard),
+        )
         .route("/admin/v1/stats/token-activity", get(stats_token_activity))
         .route("/admin/v1/stats/token-summary", get(stats_token_summary))
         .route("/admin/v1/audit", get(list_audit))
@@ -3206,6 +3210,17 @@ async fn stats_token_activity(
             Err(e) => return Err(AdminError::Db(e)),
         };
     Ok(Json(json!({"days": activity})).into_response())
+}
+
+async fn stats_token_dashboard(
+    State(state): State<AdminState>,
+    axum::extract::Query(q): axum::extract::Query<TokenActivityQuery>,
+) -> Result<Response, AdminError> {
+    let days = q.days.unwrap_or(365).clamp(1, 730);
+    let dashboard = tiygate_store::token_stats::get_token_dashboard(state.pool.as_ref(), days)
+        .await
+        .map_err(AdminError::Db)?;
+    Ok(Json(dashboard).into_response())
 }
 
 async fn stats_token_summary(State(state): State<AdminState>) -> Result<Response, AdminError> {

--- a/crates/admin/tests/integration.rs
+++ b/crates/admin/tests/integration.rs
@@ -681,6 +681,45 @@ async fn acceptance_3_stats_by_provider_endpoint() {
     assert_eq!(buckets[0]["cost"], 42_000);
 }
 
+#[tokio::test]
+async fn token_dashboard_endpoint_returns_activity_and_summary_together() {
+    let (router, _store, pool) = boot_no_auth().await;
+    let now = chrono::Utc::now();
+    sqlx::query(
+        "INSERT INTO request_logs \
+            (request_id, ts, virtual_model, ingress_protocol, status, total_tokens) \
+         VALUES ($1, $2, 'gpt-4o', 'openai/chat-completions/v1', 'ok', $3)",
+    )
+    .bind("token-dashboard-request")
+    .bind(now.to_rfc3339())
+    .bind(1_400_000_000_i64)
+    .execute(pool.any())
+    .await
+    .expect("insert request log");
+    tiygate_store::token_stats::aggregate_once(pool.as_ref(), 30)
+        .await
+        .expect("aggregate token stats");
+
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/v1/stats/token-dashboard?days=365")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 8192)
+        .await
+        .expect("response body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("response JSON");
+    assert_eq!(body["days"][0]["total_tokens"], 1_400_000_000_i64);
+    assert_eq!(body["summary"]["lifetime_tokens"], 1_400_000_000_i64);
+    assert_eq!(body["summary"]["peak_day_tokens"], 1_400_000_000_i64);
+}
+
 // ---- Acceptance #4: config and log are separate tables ----
 
 #[tokio::test]

--- a/crates/store/migrations/log/20260101000017_token_stats_bigint.sql
+++ b/crates/store/migrations/log/20260101000017_token_stats_bigint.sql
@@ -1,0 +1,4 @@
+-- SQLite INTEGER is already a signed 64-bit value, so no schema change is
+-- needed for the token/cost counters. Keep migration versions aligned with
+-- PostgreSQL and record the compatibility step.
+SELECT 1;

--- a/crates/store/migrations/postgres/log/20260101000017_token_stats_bigint.sql
+++ b/crates/store/migrations/postgres/log/20260101000017_token_stats_bigint.sql
@@ -1,0 +1,21 @@
+-- Token and cost counters must not be limited to PostgreSQL's 32-bit INTEGER.
+-- A busy gateway can exceed 2,147,483,647 lifetime tokens in a short period.
+
+ALTER TABLE token_daily_stats
+    ALTER COLUMN request_count TYPE BIGINT USING request_count::bigint,
+    ALTER COLUMN total_tokens TYPE BIGINT USING total_tokens::bigint,
+    ALTER COLUMN prompt_tokens TYPE BIGINT USING prompt_tokens::bigint,
+    ALTER COLUMN completion_tokens TYPE BIGINT USING completion_tokens::bigint,
+    ALTER COLUMN reasoning_tokens TYPE BIGINT USING reasoning_tokens::bigint,
+    ALTER COLUMN total_cost TYPE BIGINT USING total_cost::bigint,
+    ALTER COLUMN peak_single_request TYPE BIGINT USING peak_single_request::bigint,
+    ALTER COLUMN longest_task_ms TYPE BIGINT USING longest_task_ms::bigint;
+
+ALTER TABLE token_summary
+    ALTER COLUMN lifetime_tokens TYPE BIGINT USING lifetime_tokens::bigint,
+    ALTER COLUMN peak_day_tokens TYPE BIGINT USING peak_day_tokens::bigint,
+    ALTER COLUMN longest_task_ms TYPE BIGINT USING longest_task_ms::bigint,
+    ALTER COLUMN current_streak TYPE BIGINT USING current_streak::bigint,
+    ALTER COLUMN longest_streak TYPE BIGINT USING longest_streak::bigint,
+    ALTER COLUMN lifetime_cost TYPE BIGINT USING lifetime_cost::bigint,
+    ALTER COLUMN peak_day_cost TYPE BIGINT USING peak_day_cost::bigint;

--- a/crates/store/src/config_store.rs
+++ b/crates/store/src/config_store.rs
@@ -1875,14 +1875,13 @@ impl DbConfigStore {
             report.token_stats_imported += 1;
         }
 
-        tx.commit().await?;
-        // Recompute the token_summary from the merged daily stats so
-        // lifetime/peak/streaks reflect the combined data. This runs
-        // after commit because recompute_summary uses the pool
-        // directly (compute_streaks queries via pool.any()).
+        // Keep the merged daily rows and their derived summary in the same
+        // transaction. A failed summary recomputation now rolls back the
+        // imported token stats instead of exposing a partial state.
         if report.token_stats_imported > 0 {
-            crate::token_stats::recompute_summary(&self.pool).await?;
+            crate::token_stats::recompute_summary_in_tx(&mut tx).await?;
         }
+        tx.commit().await?;
         // Refresh the in-memory snapshot so the data plane picks up
         // the newly imported rows immediately.
         self.refresh().await?;
@@ -3841,6 +3840,54 @@ mod tests {
         // current streak = 2 (yesterday + today)
         assert_eq!(summary.current_streak, 2);
         assert_eq!(summary.longest_streak, 2);
+    }
+
+    #[tokio::test]
+    async fn import_token_stats_rolls_back_when_summary_update_fails() {
+        let store = boot_store(None).await;
+        let today_str = chrono::Utc::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        sqlx::query(
+            "CREATE TRIGGER fail_import_summary_update \
+             BEFORE UPDATE ON token_summary \
+             BEGIN SELECT RAISE(FAIL, 'forced summary failure'); END",
+        )
+        .execute(store.pool.any())
+        .await
+        .expect("create trigger");
+
+        let bundle = ConfigExport {
+            schema_version: 2,
+            exported_at: chrono::Utc::now().to_rfc3339(),
+            encrypted: false,
+            providers: vec![],
+            routes: vec![],
+            api_keys: vec![],
+            settings: vec![],
+            token_daily_stats: vec![ExportTokenDailyStat {
+                day: today_str.clone(),
+                request_count: 1,
+                total_tokens: 500,
+                prompt_tokens: 250,
+                completion_tokens: 250,
+                reasoning_tokens: 0,
+                total_cost: 10_000,
+                peak_single_request: 500,
+                longest_task_ms: 1000,
+            }],
+        };
+        let selection = ImportSelection {
+            token_stats: vec![today_str],
+            ..Default::default()
+        };
+
+        assert!(store.import_config(&bundle, "", &selection).await.is_err());
+        let activity = crate::token_stats::get_token_activity(&store.pool, 365)
+            .await
+            .expect("activity after rollback");
+        assert!(activity.is_empty(), "imported daily row must roll back");
     }
 
     #[tokio::test]

--- a/crates/store/src/config_store.rs
+++ b/crates/store/src/config_store.rs
@@ -1856,8 +1856,12 @@ impl DbConfigStore {
                     completion_tokens = token_daily_stats.completion_tokens + excluded.completion_tokens, \
                     reasoning_tokens = token_daily_stats.reasoning_tokens + excluded.reasoning_tokens, \
                     total_cost = token_daily_stats.total_cost + excluded.total_cost, \
-                    peak_single_request = MAX(token_daily_stats.peak_single_request, excluded.peak_single_request), \
-                    longest_task_ms = MAX(token_daily_stats.longest_task_ms, excluded.longest_task_ms), \
+                    peak_single_request = CASE \
+                        WHEN token_daily_stats.peak_single_request > excluded.peak_single_request \
+                        THEN token_daily_stats.peak_single_request ELSE excluded.peak_single_request END, \
+                    longest_task_ms = CASE \
+                        WHEN token_daily_stats.longest_task_ms > excluded.longest_task_ms \
+                        THEN token_daily_stats.longest_task_ms ELSE excluded.longest_task_ms END, \
                     updated_at = excluded.updated_at",
             )
             .bind(&s.day)

--- a/crates/store/src/log_sink/oltp.rs
+++ b/crates/store/src/log_sink/oltp.rs
@@ -2601,14 +2601,14 @@ pub async fn aggregate_by_model(
 ) -> Result<Vec<StatsBucket>, sqlx::Error> {
     let rows = sqlx::query(
         "SELECT virtual_model, COUNT(*) AS c, \
-                SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS e, \
-                COALESCE(SUM(prompt_tokens), 0) AS pt, \
-                COALESCE(SUM(completion_tokens), 0) AS ct, \
-                COALESCE(SUM(reasoning_tokens), 0) AS rt, \
-                COALESCE(SUM(cache_read_tokens), 0) AS crt, \
-                COALESCE(SUM(cache_write_tokens), 0) AS cwt, \
-                COALESCE(SUM(total_tokens), 0) AS tt, \
-                COALESCE(SUM(cost), 0) AS cost \
+                CAST(SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS BIGINT) AS e, \
+                CAST(COALESCE(SUM(prompt_tokens), 0) AS BIGINT) AS pt, \
+                CAST(COALESCE(SUM(completion_tokens), 0) AS BIGINT) AS ct, \
+                CAST(COALESCE(SUM(reasoning_tokens), 0) AS BIGINT) AS rt, \
+                CAST(COALESCE(SUM(cache_read_tokens), 0) AS BIGINT) AS crt, \
+                CAST(COALESCE(SUM(cache_write_tokens), 0) AS BIGINT) AS cwt, \
+                CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) AS tt, \
+                CAST(COALESCE(SUM(cost), 0) AS BIGINT) AS cost \
          FROM request_logs \
          WHERE ts >= $1 AND ts < $2 \
          GROUP BY virtual_model \
@@ -2645,14 +2645,14 @@ pub async fn aggregate_by_provider(
 ) -> Result<Vec<StatsBucket>, sqlx::Error> {
     let rows = sqlx::query(
         "SELECT COALESCE(resolved_provider, 'unknown') AS provider, COUNT(*) AS c, \
-                SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS e, \
-                COALESCE(SUM(prompt_tokens), 0) AS pt, \
-                COALESCE(SUM(completion_tokens), 0) AS ct, \
-                COALESCE(SUM(reasoning_tokens), 0) AS rt, \
-                COALESCE(SUM(cache_read_tokens), 0) AS crt, \
-                COALESCE(SUM(cache_write_tokens), 0) AS cwt, \
-                COALESCE(SUM(total_tokens), 0) AS tt, \
-                COALESCE(SUM(cost), 0) AS cost \
+                CAST(SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS BIGINT) AS e, \
+                CAST(COALESCE(SUM(prompt_tokens), 0) AS BIGINT) AS pt, \
+                CAST(COALESCE(SUM(completion_tokens), 0) AS BIGINT) AS ct, \
+                CAST(COALESCE(SUM(reasoning_tokens), 0) AS BIGINT) AS rt, \
+                CAST(COALESCE(SUM(cache_read_tokens), 0) AS BIGINT) AS crt, \
+                CAST(COALESCE(SUM(cache_write_tokens), 0) AS BIGINT) AS cwt, \
+                CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) AS tt, \
+                CAST(COALESCE(SUM(cost), 0) AS BIGINT) AS cost \
          FROM request_logs \
          WHERE ts >= $1 AND ts < $2 \
          GROUP BY provider \
@@ -2689,14 +2689,14 @@ pub async fn aggregate_by_api_key(
 ) -> Result<Vec<StatsBucket>, sqlx::Error> {
     let rows = sqlx::query(
         "SELECT COALESCE(api_key_id, 'anonymous') AS api_key, COUNT(*) AS c, \
-                SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS e, \
-                COALESCE(SUM(prompt_tokens), 0) AS pt, \
-                COALESCE(SUM(completion_tokens), 0) AS ct, \
-                COALESCE(SUM(reasoning_tokens), 0) AS rt, \
-                COALESCE(SUM(cache_read_tokens), 0) AS crt, \
-                COALESCE(SUM(cache_write_tokens), 0) AS cwt, \
-                COALESCE(SUM(total_tokens), 0) AS tt, \
-                COALESCE(SUM(cost), 0) AS cost \
+                CAST(SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS BIGINT) AS e, \
+                CAST(COALESCE(SUM(prompt_tokens), 0) AS BIGINT) AS pt, \
+                CAST(COALESCE(SUM(completion_tokens), 0) AS BIGINT) AS ct, \
+                CAST(COALESCE(SUM(reasoning_tokens), 0) AS BIGINT) AS rt, \
+                CAST(COALESCE(SUM(cache_read_tokens), 0) AS BIGINT) AS crt, \
+                CAST(COALESCE(SUM(cache_write_tokens), 0) AS BIGINT) AS cwt, \
+                CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) AS tt, \
+                CAST(COALESCE(SUM(cost), 0) AS BIGINT) AS cost \
          FROM request_logs \
          WHERE ts >= $1 AND ts < $2 \
          GROUP BY api_key \
@@ -2738,14 +2738,14 @@ pub async fn aggregate_by_target(
         "SELECT \
                 COALESCE(resolved_provider, 'unknown') || ' / ' || COALESCE(resolved_model, 'unknown') AS target, \
                 COUNT(*) AS c, \
-                SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS e, \
-                COALESCE(SUM(prompt_tokens), 0) AS pt, \
-                COALESCE(SUM(completion_tokens), 0) AS ct, \
-                COALESCE(SUM(reasoning_tokens), 0) AS rt, \
-                COALESCE(SUM(cache_read_tokens), 0) AS crt, \
-                COALESCE(SUM(cache_write_tokens), 0) AS cwt, \
-                COALESCE(SUM(total_tokens), 0) AS tt, \
-                COALESCE(SUM(cost), 0) AS cost, \
+                CAST(SUM(CASE WHEN status NOT IN ('ok', 'success') THEN 1 ELSE 0 END) AS BIGINT) AS e, \
+                CAST(COALESCE(SUM(prompt_tokens), 0) AS BIGINT) AS pt, \
+                CAST(COALESCE(SUM(completion_tokens), 0) AS BIGINT) AS ct, \
+                CAST(COALESCE(SUM(reasoning_tokens), 0) AS BIGINT) AS rt, \
+                CAST(COALESCE(SUM(cache_read_tokens), 0) AS BIGINT) AS crt, \
+                CAST(COALESCE(SUM(cache_write_tokens), 0) AS BIGINT) AS cwt, \
+                CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) AS tt, \
+                CAST(COALESCE(SUM(cost), 0) AS BIGINT) AS cost, \
                 CAST(AVG(ttfb_ms) AS DOUBLE PRECISION) AS alat, \
                 CASE WHEN SUM(stream_duration_ms) > 0 \
                      THEN CAST(SUM(completion_tokens) * 1000.0 / SUM(stream_duration_ms) AS DOUBLE PRECISION) \

--- a/crates/store/src/token_stats.rs
+++ b/crates/store/src/token_stats.rs
@@ -20,7 +20,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use crate::config_store::DbConfigStore;
-use crate::db::DbPool;
+use crate::db::{DbKind, DbPool};
 use crate::models::ExportTokenDailyStat;
 use crate::settings_keys;
 
@@ -117,24 +117,14 @@ pub async fn aggregate_once(pool: &DbPool, lookback_days: u32) -> Result<(), sql
     let mut tx = pool.any().begin().await?;
 
     // Step 1: Aggregate per-day stats from request_logs.
-    let rows = sqlx::query(
-        "SELECT CAST(DATE(ts) AS TEXT) AS day, \
-                COUNT(*) AS cnt, \
-                COALESCE(SUM(total_tokens), 0) AS tt, \
-                COALESCE(SUM(prompt_tokens), 0) AS pt, \
-                COALESCE(SUM(completion_tokens), 0) AS ct, \
-                COALESCE(SUM(reasoning_tokens), 0) AS rt, \
-                COALESCE(SUM(cost), 0) AS tc, \
-                COALESCE(MAX(total_tokens), 0) AS peak_req, \
-                COALESCE(MAX(total_latency_ms), 0) AS longest_ms \
-         FROM request_logs \
-         WHERE ts >= $1 \
-         GROUP BY DATE(ts) \
-         ORDER BY day",
-    )
-    .bind(&since_str)
-    .fetch_all(&mut *tx)
-    .await?;
+    // `ts` is deliberately stored as TEXT for SQLite/PostgreSQL parity, but
+    // DATE(text) is not a valid PostgreSQL function call. Keep the two SQL
+    // dialects explicit so the worker does not fail every pass on PG.
+    let aggregation_sql = aggregation_sql(pool.kind());
+    let rows = sqlx::query(aggregation_sql)
+        .bind(&since_str)
+        .fetch_all(&mut *tx)
+        .await?;
 
     let updated_at = now.to_rfc3339();
 
@@ -194,6 +184,47 @@ pub async fn aggregate_once(pool: &DbPool, lookback_days: u32) -> Result<(), sql
     Ok(())
 }
 
+/// SQL used to aggregate request logs by UTC calendar day. PostgreSQL and
+/// SQLite expose different date functions because `request_logs.ts` is TEXT
+/// on both backends.
+fn aggregation_sql(kind: DbKind) -> &'static str {
+    match kind {
+        DbKind::Sqlite => {
+            "SELECT CAST(DATE(ts) AS TEXT) AS day, \
+                    COUNT(*) AS cnt, \
+                    CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) AS tt, \
+                    CAST(COALESCE(SUM(prompt_tokens), 0) AS BIGINT) AS pt, \
+                    CAST(COALESCE(SUM(completion_tokens), 0) AS BIGINT) AS ct, \
+                    CAST(COALESCE(SUM(reasoning_tokens), 0) AS BIGINT) AS rt, \
+                    CAST(COALESCE(SUM(cost), 0) AS BIGINT) AS tc, \
+                    COALESCE(MAX(total_tokens), 0) AS peak_req, \
+                    COALESCE(MAX(total_latency_ms), 0) AS longest_ms \
+             FROM request_logs \
+             WHERE ts >= $1 \
+             GROUP BY DATE(ts) \
+             ORDER BY day"
+        }
+        DbKind::Postgres => {
+            // `ts` is written as UTC RFC-3339 text by the sink, so the
+            // lower-bound comparison can use the indexed TEXT column while
+            // the grouping expression performs the explicit UTC conversion.
+            "SELECT TO_CHAR((ts::timestamptz AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS day, \
+                    COUNT(*) AS cnt, \
+                    CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) AS tt, \
+                    CAST(COALESCE(SUM(prompt_tokens), 0) AS BIGINT) AS pt, \
+                    CAST(COALESCE(SUM(completion_tokens), 0) AS BIGINT) AS ct, \
+                    CAST(COALESCE(SUM(reasoning_tokens), 0) AS BIGINT) AS rt, \
+                    CAST(COALESCE(SUM(cost), 0) AS BIGINT) AS tc, \
+                    COALESCE(MAX(total_tokens), 0) AS peak_req, \
+                    COALESCE(MAX(total_latency_ms), 0) AS longest_ms \
+             FROM request_logs \
+             WHERE ts >= $1 \
+             GROUP BY (ts::timestamptz AT TIME ZONE 'UTC')::date \
+             ORDER BY day"
+        }
+    }
+}
+
 /// Recompute the single-row `token_summary` table from the current
 /// contents of `token_daily_stats`. Computes `lifetime_tokens`
 /// (SUM), `peak_day_tokens` (MAX), `longest_task_ms` (MAX), and
@@ -216,10 +247,11 @@ pub(crate) async fn recompute_summary_in_tx(
     let today = now.date_naive();
     let updated_at = now.to_rfc3339();
 
-    let lifetime_tokens: i64 =
-        sqlx::query_scalar("SELECT COALESCE(SUM(total_tokens), 0) FROM token_daily_stats")
-            .fetch_one(&mut **tx)
-            .await?;
+    let lifetime_tokens: i64 = sqlx::query_scalar(
+        "SELECT CAST(COALESCE(SUM(total_tokens), 0) AS BIGINT) FROM token_daily_stats",
+    )
+    .fetch_one(&mut **tx)
+    .await?;
 
     let peak_day_tokens: i64 =
         sqlx::query_scalar("SELECT COALESCE(MAX(total_tokens), 0) FROM token_daily_stats")
@@ -231,10 +263,11 @@ pub(crate) async fn recompute_summary_in_tx(
             .fetch_one(&mut **tx)
             .await?;
 
-    let lifetime_cost: i64 =
-        sqlx::query_scalar("SELECT COALESCE(SUM(total_cost), 0) FROM token_daily_stats")
-            .fetch_one(&mut **tx)
-            .await?;
+    let lifetime_cost: i64 = sqlx::query_scalar(
+        "SELECT CAST(COALESCE(SUM(total_cost), 0) AS BIGINT) FROM token_daily_stats",
+    )
+    .fetch_one(&mut **tx)
+    .await?;
 
     let peak_day_cost: i64 =
         sqlx::query_scalar("SELECT COALESCE(MAX(total_cost), 0) FROM token_daily_stats")
@@ -657,5 +690,13 @@ mod tests {
         let summary = get_token_summary(pool.as_ref()).await.expect("summary");
         assert_eq!(summary.current_streak, 0);
         assert_eq!(summary.longest_streak, 1);
+    }
+
+    #[test]
+    fn postgres_aggregation_uses_utc_timestamptz_casts() {
+        let sql = aggregation_sql(DbKind::Postgres);
+        assert!(sql.contains("ts::timestamptz"));
+        assert!(sql.contains("AT TIME ZONE 'UTC'"));
+        assert!(!sql.contains("DATE(ts)"));
     }
 }

--- a/crates/store/src/token_stats.rs
+++ b/crates/store/src/token_stats.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{NaiveDate, Utc};
-use sqlx::Row;
+use sqlx::{Any, Row, Transaction};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
@@ -114,6 +114,7 @@ pub async fn aggregate_once(pool: &DbPool, lookback_days: u32) -> Result<(), sql
     let today = now.date_naive();
     let since = today - chrono::Duration::days(lookback_days as i64);
     let since_str = since.format("%Y-%m-%d").to_string();
+    let mut tx = pool.any().begin().await?;
 
     // Step 1: Aggregate per-day stats from request_logs.
     let rows = sqlx::query(
@@ -132,7 +133,7 @@ pub async fn aggregate_once(pool: &DbPool, lookback_days: u32) -> Result<(), sql
          ORDER BY day",
     )
     .bind(&since_str)
-    .fetch_all(pool.any())
+    .fetch_all(&mut *tx)
     .await?;
 
     let updated_at = now.to_rfc3339();
@@ -175,12 +176,15 @@ pub async fn aggregate_once(pool: &DbPool, lookback_days: u32) -> Result<(), sql
         .bind(peak_single_request)
         .bind(longest_task_ms)
         .bind(&updated_at)
-        .execute(pool.any())
+        .execute(&mut *tx)
         .await?;
     }
 
-    // Step 3: Recompute summary from token_daily_stats.
-    recompute_summary(pool).await?;
+    // Step 3: Recompute the summary in the same transaction as the daily
+    // rows. Readers therefore see either the complete old snapshot or the
+    // complete new snapshot, never fresh daily rows with a stale summary.
+    recompute_summary_in_tx(&mut tx).await?;
+    tx.commit().await?;
 
     debug!(
         days_aggregated = rows.len(),
@@ -196,36 +200,48 @@ pub async fn aggregate_once(pool: &DbPool, lookback_days: u32) -> Result<(), sql
 /// streaks (via `compute_streaks`). Public so the config import
 /// path can call it after merging imported daily stats.
 pub async fn recompute_summary(pool: &DbPool) -> Result<(), sqlx::Error> {
+    let mut tx = pool.any().begin().await?;
+    recompute_summary_in_tx(&mut tx).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Recompute `token_summary` using the caller's transaction. Kept
+/// crate-visible so config import can include the merged daily rows and the
+/// derived summary in one atomic commit.
+pub(crate) async fn recompute_summary_in_tx(
+    tx: &mut Transaction<'_, Any>,
+) -> Result<(), sqlx::Error> {
     let now = Utc::now();
     let today = now.date_naive();
     let updated_at = now.to_rfc3339();
 
     let lifetime_tokens: i64 =
         sqlx::query_scalar("SELECT COALESCE(SUM(total_tokens), 0) FROM token_daily_stats")
-            .fetch_one(pool.any())
+            .fetch_one(&mut **tx)
             .await?;
 
     let peak_day_tokens: i64 =
         sqlx::query_scalar("SELECT COALESCE(MAX(total_tokens), 0) FROM token_daily_stats")
-            .fetch_one(pool.any())
+            .fetch_one(&mut **tx)
             .await?;
 
     let longest_task_ms: i64 =
         sqlx::query_scalar("SELECT COALESCE(MAX(longest_task_ms), 0) FROM token_daily_stats")
-            .fetch_one(pool.any())
+            .fetch_one(&mut **tx)
             .await?;
 
     let lifetime_cost: i64 =
         sqlx::query_scalar("SELECT COALESCE(SUM(total_cost), 0) FROM token_daily_stats")
-            .fetch_one(pool.any())
+            .fetch_one(&mut **tx)
             .await?;
 
     let peak_day_cost: i64 =
         sqlx::query_scalar("SELECT COALESCE(MAX(total_cost), 0) FROM token_daily_stats")
-            .fetch_one(pool.any())
+            .fetch_one(&mut **tx)
             .await?;
 
-    let (current_streak, longest_streak) = compute_streaks(pool, today).await?;
+    let (current_streak, longest_streak) = compute_streaks_in_tx(tx, today).await?;
 
     sqlx::query(
         "UPDATE token_summary SET \
@@ -247,7 +263,7 @@ pub async fn recompute_summary(pool: &DbPool) -> Result<(), sqlx::Error> {
     .bind(current_streak)
     .bind(longest_streak)
     .bind(&updated_at)
-    .execute(pool.any())
+    .execute(&mut **tx)
     .await?;
 
     debug!(
@@ -260,12 +276,15 @@ pub async fn recompute_summary(pool: &DbPool) -> Result<(), sqlx::Error> {
 
 /// Compute the current streak (consecutive days ending at `today`) and
 /// the longest streak ever from `token_daily_stats`.
-async fn compute_streaks(pool: &DbPool, today: NaiveDate) -> Result<(i64, i64), sqlx::Error> {
+async fn compute_streaks_in_tx(
+    tx: &mut Transaction<'_, Any>,
+    today: NaiveDate,
+) -> Result<(i64, i64), sqlx::Error> {
     // Fetch all active days (those with at least 1 token) ordered descending.
     let days: Vec<String> = sqlx::query_scalar(
         "SELECT day FROM token_daily_stats WHERE total_tokens > 0 ORDER BY day DESC",
     )
-    .fetch_all(pool.any())
+    .fetch_all(&mut **tx)
     .await?;
 
     if days.is_empty() {
@@ -373,6 +392,72 @@ pub struct TokenSummaryData {
     pub current_streak: i64,
     pub longest_streak: i64,
     pub updated_at: String,
+}
+
+/// Atomic dashboard payload: daily activity and its derived summary are read
+/// from one database snapshot and returned by one Admin API request.
+#[derive(Debug, serde::Serialize)]
+pub struct TokenDashboardData {
+    pub days: Vec<TokenDayActivity>,
+    pub summary: TokenSummaryData,
+}
+
+/// Fetch the complete Token Activity dashboard snapshot. PostgreSQL defaults
+/// to READ COMMITTED (a new snapshot per statement), so explicitly promote
+/// this short read transaction to REPEATABLE READ. SQLite already pins the
+/// snapshot on the first read in a transaction.
+pub async fn get_token_dashboard(
+    pool: &DbPool,
+    days: u32,
+) -> Result<TokenDashboardData, sqlx::Error> {
+    let mut tx = pool.any().begin().await?;
+    if pool.kind() == crate::db::DbKind::Postgres {
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    let summary_row = sqlx::query(
+        "SELECT lifetime_tokens, peak_day_tokens, lifetime_cost, peak_day_cost, \
+                longest_task_ms, current_streak, longest_streak, updated_at \
+         FROM token_summary WHERE id = 1",
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+    let summary = TokenSummaryData {
+        lifetime_tokens: summary_row.get("lifetime_tokens"),
+        peak_day_tokens: summary_row.get("peak_day_tokens"),
+        lifetime_cost: summary_row.get("lifetime_cost"),
+        peak_day_cost: summary_row.get("peak_day_cost"),
+        longest_task_ms: summary_row.get("longest_task_ms"),
+        current_streak: summary_row.get("current_streak"),
+        longest_streak: summary_row.get("longest_streak"),
+        updated_at: summary_row.get("updated_at"),
+    };
+
+    let rows = sqlx::query(
+        "SELECT day, total_tokens, total_cost, request_count \
+         FROM token_daily_stats ORDER BY day DESC LIMIT $1",
+    )
+    .bind(days as i64)
+    .fetch_all(&mut *tx)
+    .await?;
+    let mut activity = Vec::with_capacity(rows.len());
+    for row in rows {
+        activity.push(TokenDayActivity {
+            day: row.get("day"),
+            total_tokens: row.get("total_tokens"),
+            total_cost: row.get("total_cost"),
+            request_count: row.get("request_count"),
+        });
+    }
+    activity.reverse();
+    tx.commit().await?;
+
+    Ok(TokenDashboardData {
+        days: activity,
+        summary,
+    })
 }
 
 /// Fetch the pre-computed summary from the single-row table.
@@ -516,6 +601,46 @@ mod tests {
         assert_eq!(summary.longest_task_ms, 8000);
         assert_eq!(summary.current_streak, 2);
         assert_eq!(summary.longest_streak, 2);
+
+        let dashboard = get_token_dashboard(pool.as_ref(), 365)
+            .await
+            .expect("dashboard");
+        assert_eq!(dashboard.days.len(), 2);
+        assert_eq!(dashboard.days[1].total_tokens, 300);
+        assert_eq!(dashboard.summary.lifetime_tokens, 450);
+        assert_eq!(dashboard.summary.peak_day_tokens, 300);
+    }
+
+    #[tokio::test]
+    async fn aggregate_rolls_back_daily_rows_when_summary_update_fails() {
+        let pool = in_mem_pool().await;
+        let today = Utc::now().date_naive();
+        let today_ts = format!("{}T10:00:00Z", today);
+        insert_log(pool.as_ref(), "req-atomic", &today_ts, 100, 5000, None).await;
+
+        // Force the final step to fail. The daily upsert must be part of the
+        // same transaction and therefore must not leak out after rollback.
+        sqlx::query(
+            "CREATE TRIGGER fail_token_summary_update \
+             BEFORE UPDATE ON token_summary \
+             BEGIN SELECT RAISE(FAIL, 'forced summary failure'); END",
+        )
+        .execute(pool.any())
+        .await
+        .expect("create trigger");
+
+        assert!(aggregate_once(pool.as_ref(), 30).await.is_err());
+        let activity = get_token_activity(pool.as_ref(), 365)
+            .await
+            .expect("activity after rollback");
+        assert!(
+            activity.is_empty(),
+            "daily rows must roll back with summary"
+        );
+
+        let summary = get_token_summary(pool.as_ref()).await.expect("summary");
+        assert_eq!(summary.lifetime_tokens, 0);
+        assert_eq!(summary.peak_day_tokens, 0);
     }
 
     #[tokio::test]

--- a/webui/src/api/resources.ts
+++ b/webui/src/api/resources.ts
@@ -31,6 +31,7 @@ import type {
   Settings,
   SettingsResponse,
   StatsResponse,
+  TokenDashboardData,
   TokenActivityResponse,
   TokenSummaryData,
 } from "./types";
@@ -156,6 +157,10 @@ export const statsApi = {
     apiRequest<StatsResponse>("/stats/by-api-key", { query: range }),
   byTarget: (range: StatsRange = {}) =>
     apiRequest<StatsResponse>("/stats/by-target", { query: range }),
+  tokenDashboard: (days = 365) =>
+    apiRequest<TokenDashboardData>("/stats/token-dashboard", {
+      query: { days },
+    }),
   tokenActivity: (days = 365) =>
     apiRequest<TokenActivityResponse>("/stats/token-activity", {
       query: { days },

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -413,6 +413,11 @@ export interface TokenSummaryData {
   updated_at: string;
 }
 
+export interface TokenDashboardData {
+  days: TokenDayActivity[];
+  summary: TokenSummaryData;
+}
+
 // ---- server info ----
 export interface ServerInfo {
   name: string;

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -233,14 +233,9 @@ export default function Dashboard() {
     queryKey: ["circuit-breakers"],
     queryFn: healthApi.circuitBreakers,
   });
-  const tokenActivity = useQuery({
-    queryKey: ["stats", "token-activity"],
-    queryFn: () => statsApi.tokenActivity(365),
-    staleTime: 5 * 60_000,
-  });
-  const tokenSummary = useQuery({
-    queryKey: ["stats", "token-summary"],
-    queryFn: () => statsApi.tokenSummary(),
+  const tokenDashboard = useQuery({
+    queryKey: ["stats", "token-dashboard"],
+    queryFn: () => statsApi.tokenDashboard(365),
     staleTime: 5 * 60_000,
   });
   // Name directories for nicer labels in the stats tables. We keep these
@@ -312,8 +307,7 @@ export default function Dashboard() {
       byApiKey.refetch(),
       byTarget.refetch(),
       breakers.refetch(),
-      tokenActivity.refetch(),
-      tokenSummary.refetch(),
+      tokenDashboard.refetch(),
       providers.refetch(),
       apiKeys.refetch(),
     ]);
@@ -331,15 +325,14 @@ export default function Dashboard() {
       <div className="flex flex-col xl:flex-row gap-4 xl:items-stretch">
         {/* Left: heatmap — fixed intrinsic width */}
         <Card className="shrink-0 xl:w-fit">
-          {tokenActivity.error || tokenSummary.error ? (
+          {tokenDashboard.error ? (
             <div className="p-4">
               <ErrorBox
                 message={
-                  ((tokenActivity.error ?? tokenSummary.error) as Error).message
+                  (tokenDashboard.error as Error).message
                 }
                 onRetry={() => {
-                  tokenActivity.refetch();
-                  tokenSummary.refetch();
+                  tokenDashboard.refetch();
                 }}
                 retryLabel={t("common.retry")}
               />
@@ -347,8 +340,8 @@ export default function Dashboard() {
           ) : (
             <div className="p-4">
               <TokenHeatmap
-                data={tokenActivity.data?.days ?? []}
-                isLoading={tokenActivity.isLoading}
+                data={tokenDashboard.data?.days ?? []}
+                isLoading={tokenDashboard.isLoading}
               />
             </div>
           )}
@@ -357,8 +350,8 @@ export default function Dashboard() {
         {/* Non-ultrawide: only lifetime Token/cost stays beside the heatmap. */}
         <div className="min-w-0 xl:flex-1 2xl:hidden">
           <TokenSummaryBar
-            data={tokenSummary.data}
-            isLoading={tokenSummary.isLoading}
+            data={tokenDashboard.data?.summary}
+            isLoading={tokenDashboard.isLoading}
             group="lifetime"
           />
         </div>
@@ -366,16 +359,16 @@ export default function Dashboard() {
         {/* Ultrawide: keep the existing full six-card summary layout. */}
         <div className="hidden flex-1 min-w-0 2xl:block">
           <TokenSummaryBar
-            data={tokenSummary.data}
-            isLoading={tokenSummary.isLoading}
+            data={tokenDashboard.data?.summary}
+            isLoading={tokenDashboard.isLoading}
           />
         </div>
       </div>
 
       {/* Non-ultrawide: detail summary cards span the full row below token activity. */}
       <TokenSummaryBar
-        data={tokenSummary.data}
-        isLoading={tokenSummary.isLoading}
+        data={tokenDashboard.data?.summary}
+        isLoading={tokenDashboard.isLoading}
         group="details"
         className="2xl:hidden"
       />


### PR DESCRIPTION
## 摘要
- 新增原子化 Token Dashboard API，一次返回每日活动与汇总数据。
- 将 Token 日统计与派生汇总纳入同一事务，避免部分提交导致数据不一致。
- 更新 WebUI Dashboard 使用统一接口，并补充回滚与端点集成测试。

## 测试
- 新增管理端点集成测试。
- 新增统计聚合与配置导入失败回滚测试。
- 验证 Dashboard API 返回活动和汇总数据的一致快照。

🤖 Generated with [Codex](https://github.com/codex)