### PR TITLE
feat: ✨ inject x-opencode-session header for OpenCode providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5879,11 +5879,13 @@ name = "tiygate-providers"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "hex",
  "http 1.4.2",
  "inventory",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tiygate-auth",
  "tiygate-core",

--- a/crates/auth/src/oauth.rs
+++ b/crates/auth/src/oauth.rs
@@ -458,6 +458,7 @@ mod tests {
     fn dummy_target(label: Option<&str>) -> RoutingTarget {
         RoutingTarget {
             provider_id: "test".to_string(),
+            vendor: None,
             model_id: "test-model".to_string(),
             api_base: "https://example.com".to_string(),
             api_key: "placeholder".to_string(),

--- a/crates/core/src/provider/mod.rs
+++ b/crates/core/src/provider/mod.rs
@@ -87,6 +87,19 @@ pub trait Provider: Send + Sync {
     fn egress_api_base(&self, raw_base: &str, _endpoint: &ProtocolEndpoint) -> String {
         raw_base.to_string()
     }
+
+    /// Extra headers to inject into the upstream request after auth is applied.
+    ///
+    /// This allows providers to require custom headers (e.g. session tracking)
+    /// without relying on the client to send them. The default returns an
+    /// empty list.
+    ///
+    /// `api_key` is the upstream API key configured on the routing target
+    /// (not the caller's TiyGate API key). Providers can use it to derive
+    /// stable per-account session identifiers.
+    fn extra_headers(&self, _api_key: &str) -> Vec<(&'static str, String)> {
+        Vec::new()
+    }
 }
 
 /// Decentralized provider registration via `inventory`.

--- a/crates/core/src/provider/mod.rs
+++ b/crates/core/src/provider/mod.rs
@@ -94,10 +94,10 @@ pub trait Provider: Send + Sync {
     /// without relying on the client to send them. The default returns an
     /// empty list.
     ///
-    /// `api_key` is the upstream API key configured on the routing target
-    /// (not the caller's TiyGate API key). Providers can use it to derive
-    /// stable per-account session identifiers.
-    fn extra_headers(&self, _api_key: &str) -> Vec<(&'static str, String)> {
+    /// `caller_key_id` is the caller's TiyGate API key ID (not the upstream
+    /// provider key). Providers can use it to derive stable per-customer
+    /// session identifiers.
+    fn extra_headers(&self, _caller_key_id: &str) -> Vec<(&'static str, String)> {
         Vec::new()
     }
 }

--- a/crates/core/src/routing/mod.rs
+++ b/crates/core/src/routing/mod.rs
@@ -19,6 +19,11 @@ use crate::telemetry::RequestErrorClass;
 pub struct RoutingTarget {
     /// Provider identifier (e.g., "openai", "anthropic").
     pub provider_id: String,
+    /// Provider vendor name for registered-provider lookup (e.g., "opencode-go").
+    /// Used by `find_provider` to match the in-memory provider registration.
+    /// Falls back to `provider_id` when not set (legacy targets).
+    #[serde(default)]
+    pub vendor: Option<String>,
     /// The specific model name to send to the upstream.
     pub model_id: String,
     /// The API base URL.

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -18,6 +18,7 @@ mod tests {
         let mut table = RoutingTable::new();
         let targets = vec![RoutingTarget {
             provider_id: "openai".to_string(),
+            vendor: None,
             model_id: "gpt-4o".to_string(),
             api_base: "https://api.openai.com/v1".to_string(),
             api_key: "sk-test".to_string(),

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -45,6 +45,7 @@ mod tests {
     fn test_routing_table_per_route_strategy() {
         let mk_target = || RoutingTarget {
             provider_id: "openai".to_string(),
+            vendor: None,
             model_id: "gpt-4o".to_string(),
             api_base: "https://api.openai.com/v1".to_string(),
             api_key: "sk-test".to_string(),
@@ -105,6 +106,7 @@ mod tests {
     fn test_routing_target_effective_key() {
         let target = RoutingTarget {
             provider_id: "test".to_string(),
+            vendor: None,
             model_id: "test-model".to_string(),
             api_base: "https://test.api".to_string(),
             api_key: "original-key".to_string(),
@@ -426,6 +428,7 @@ mod tests {
         let policy = DefaultFallbackPolicy::with_defaults();
         let target = RoutingTarget {
             provider_id: "test".to_string(),
+            vendor: None,
             model_id: "m".to_string(),
             api_base: "https://test".to_string(),
             api_key: "k".to_string(),
@@ -452,6 +455,7 @@ mod tests {
         let policy = DefaultFallbackPolicy::with_defaults();
         let target = RoutingTarget {
             provider_id: "test".to_string(),
+            vendor: None,
             model_id: "m".to_string(),
             api_base: "https://test".to_string(),
             api_key: "k".to_string(),
@@ -525,6 +529,7 @@ mod tests {
         let targets = vec![
             RoutingTarget {
                 provider_id: "a".to_string(),
+                vendor: None,
                 model_id: "m".to_string(),
                 api_base: "https://a".to_string(),
                 api_key: "k".to_string(),
@@ -537,6 +542,7 @@ mod tests {
             },
             RoutingTarget {
                 provider_id: "b".to_string(),
+                vendor: None,
                 model_id: "m".to_string(),
                 api_base: "https://b".to_string(),
                 api_key: "k".to_string(),
@@ -559,6 +565,7 @@ mod tests {
         let targets = vec![
             RoutingTarget {
                 provider_id: "low".to_string(),
+                vendor: None,
                 model_id: "m".to_string(),
                 api_base: "https://low".to_string(),
                 api_key: "k".to_string(),
@@ -571,6 +578,7 @@ mod tests {
             },
             RoutingTarget {
                 provider_id: "high".to_string(),
+                vendor: None,
                 model_id: "m".to_string(),
                 api_base: "https://high".to_string(),
                 api_key: "k".to_string(),
@@ -598,6 +606,7 @@ mod tests {
         let targets = vec![
             RoutingTarget {
                 provider_id: "healthy".to_string(),
+                vendor: None,
                 model_id: "m".to_string(),
                 api_base: "https://healthy".to_string(),
                 api_key: "k".to_string(),
@@ -610,6 +619,7 @@ mod tests {
             },
             RoutingTarget {
                 provider_id: "broken".to_string(),
+                vendor: None,
                 model_id: "m".to_string(),
                 api_base: "https://broken".to_string(),
                 api_key: "k".to_string(),
@@ -637,6 +647,7 @@ mod tests {
             DefaultFallbackPolicy::new(3, Duration::from_secs(120), RetryPolicy::with_defaults());
         let target = RoutingTarget {
             provider_id: "test".to_string(),
+            vendor: None,
             model_id: "m".to_string(),
             api_base: "https://test".to_string(),
             api_key: "k".to_string(),
@@ -676,6 +687,7 @@ mod tests {
         let targets = vec![
             RoutingTarget {
                 provider_id: "a".to_string(),
+                vendor: None,
                 model_id: "model".to_string(),
                 api_base: "https://a".to_string(),
                 api_key: "k".to_string(),
@@ -688,6 +700,7 @@ mod tests {
             },
             RoutingTarget {
                 provider_id: "b".to_string(),
+                vendor: None,
                 model_id: "model".to_string(),
                 api_base: "https://b".to_string(),
                 api_key: "k".to_string(),
@@ -700,6 +713,7 @@ mod tests {
             },
             RoutingTarget {
                 provider_id: "c".to_string(),
+                vendor: None,
                 model_id: "model".to_string(),
                 api_base: "https://c".to_string(),
                 api_key: "k".to_string(),
@@ -743,6 +757,7 @@ mod tests {
             DefaultFallbackPolicy::new(2, Duration::from_secs(60), RetryPolicy::with_defaults());
         let target = RoutingTarget {
             provider_id: "test".to_string(),
+            vendor: None,
             model_id: "m".to_string(),
             api_base: "https://test".to_string(),
             api_key: "k".to_string(),
@@ -776,6 +791,7 @@ mod tests {
         let policy = DefaultFallbackPolicy::with_defaults();
         let target = RoutingTarget {
             provider_id: "openai".to_string(),
+            vendor: None,
             model_id: "gpt-4o".to_string(),
             api_base: "https://api.openai.com/v1".to_string(),
             api_key: "sk".to_string(),

--- a/crates/provider-bedrock/src/executor.rs
+++ b/crates/provider-bedrock/src/executor.rs
@@ -673,6 +673,7 @@ mod tests {
     fn make_target(base: &str) -> RoutingTarget {
         RoutingTarget {
             provider_id: "bedrock".to_string(),
+            vendor: None,
             model_id: "anthropic.claude-sonnet-4-20250514-v1:0".to_string(),
             api_base: base.to_string(),
             api_key: "AKID:secret:us-east-1".to_string(),

--- a/crates/provider-bedrock/src/lib.rs
+++ b/crates/provider-bedrock/src/lib.rs
@@ -138,6 +138,7 @@ mod tests {
         let applier = BedrockAuthApplier;
         let target = RoutingTarget {
             provider_id: "bedrock".to_string(),
+            vendor: None,
             model_id: "anthropic.claude-sonnet-4-20250514-v1:0".to_string(),
             api_base: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
             api_key: "AKID:secret:us-east-1".to_string(),

--- a/crates/providers/Cargo.toml
+++ b/crates/providers/Cargo.toml
@@ -16,6 +16,8 @@ http.workspace = true
 inventory.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
+sha2.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/providers/src/gemini.rs
+++ b/crates/providers/src/gemini.rs
@@ -150,6 +150,7 @@ mod tests {
     fn dummy_target(key: &str) -> RoutingTarget {
         RoutingTarget {
             provider_id: GEMINI_VENDOR_ID.to_string(),
+            vendor: None,
             model_id: "gemini-1.5-pro".to_string(),
             api_base: GEMINI_DEFAULT_BASE_URL.to_string(),
             api_key: key.to_string(),

--- a/crates/providers/src/opencode.rs
+++ b/crates/providers/src/opencode.rs
@@ -69,8 +69,8 @@ impl Provider for OpenCodeZenProvider {
         opencode_egress_protocol_for_model(model_id)
     }
 
-    fn extra_headers(&self, api_key: &str) -> Vec<(&'static str, String)> {
-        vec![("x-opencode-session", opencode_session_id(api_key))]
+    fn extra_headers(&self, caller_key_id: &str) -> Vec<(&'static str, String)> {
+        vec![("x-opencode-session", opencode_session_id(caller_key_id))]
     }
 }
 
@@ -95,20 +95,19 @@ impl Provider for OpenCodeGoProvider {
         opencode_egress_protocol_for_model(model_id)
     }
 
-    fn extra_headers(&self, api_key: &str) -> Vec<(&'static str, String)> {
-        vec![("x-opencode-session", opencode_session_id(api_key))]
+    fn extra_headers(&self, caller_key_id: &str) -> Vec<(&'static str, String)> {
+        vec![("x-opencode-session", opencode_session_id(caller_key_id))]
     }
 }
 
-/// Derive a stable session identifier from the upstream API key.
+/// Derive a stable session identifier from the caller's TiyGate key ID.
 ///
 /// OpenCode requires an `x-opencode-session` header to correlate requests
 /// into sessions for service optimization. We generate a stable SHA-256
-/// hex digest of the upstream API key so that all requests from the same
-/// key share a consistent session identifier, without requiring clients
-/// to send any custom headers.
-fn opencode_session_id(api_key: &str) -> String {
-    let digest = Sha256::digest(api_key.as_bytes());
+/// hex digest of the caller's TiyGate API key ID so that each customer
+/// gets a unique, consistent session identifier.
+fn opencode_session_id(caller_key_id: &str) -> String {
+    let digest = Sha256::digest(caller_key_id.as_bytes());
     hex::encode(digest)
 }
 

--- a/crates/providers/src/opencode.rs
+++ b/crates/providers/src/opencode.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use sha2::{Digest, Sha256};
 use tiygate_auth::bearer::BearerAuthApplier;
 use tiygate_core::{
     AuthApplier, AuthMode, ProtocolEndpoint, ProtocolSuite, Provider, ProviderMetadata,
@@ -67,6 +68,10 @@ impl Provider for OpenCodeZenProvider {
     fn egress_protocol_for_model(&self, model_id: &str) -> ProtocolEndpoint {
         opencode_egress_protocol_for_model(model_id)
     }
+
+    fn extra_headers(&self, api_key: &str) -> Vec<(&'static str, String)> {
+        vec![("x-opencode-session", opencode_session_id(api_key))]
+    }
 }
 
 impl Provider for OpenCodeGoProvider {
@@ -89,6 +94,22 @@ impl Provider for OpenCodeGoProvider {
     fn egress_protocol_for_model(&self, model_id: &str) -> ProtocolEndpoint {
         opencode_egress_protocol_for_model(model_id)
     }
+
+    fn extra_headers(&self, api_key: &str) -> Vec<(&'static str, String)> {
+        vec![("x-opencode-session", opencode_session_id(api_key))]
+    }
+}
+
+/// Derive a stable session identifier from the upstream API key.
+///
+/// OpenCode requires an `x-opencode-session` header to correlate requests
+/// into sessions for service optimization. We generate a stable SHA-256
+/// hex digest of the upstream API key so that all requests from the same
+/// key share a consistent session identifier, without requiring clients
+/// to send any custom headers.
+fn opencode_session_id(api_key: &str) -> String {
+    let digest = Sha256::digest(api_key.as_bytes());
+    hex::encode(digest)
 }
 
 fn opencode_metadata(display_name: &str, base_url: &str) -> ProviderMetadata {
@@ -260,5 +281,49 @@ mod tests {
             provider.egress_api_base("https://example.test/zen/go/v1", &compatible),
             "https://example.test/zen/go/v1"
         );
+    }
+
+    #[test]
+    fn test_opencode_extra_headers_returns_session_header() {
+        let provider = OpenCodeGoProvider::new();
+        let headers = provider.extra_headers("test-api-key-123");
+
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0, "x-opencode-session");
+        assert!(!headers[0].1.is_empty());
+    }
+
+    #[test]
+    fn test_opencode_session_id_is_deterministic() {
+        let key = "my-secret-api-key";
+        let id1 = opencode_session_id(key);
+        let id2 = opencode_session_id(key);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_opencode_session_id_varies_by_key() {
+        let id1 = opencode_session_id("key-a");
+        let id2 = opencode_session_id("key-b");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_opencode_session_id_is_64_hex_chars() {
+        let id = opencode_session_id("any-key");
+        assert_eq!(id.len(), 64);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_zen_and_go_share_session_logic() {
+        let zen = OpenCodeZenProvider::new();
+        let go = OpenCodeGoProvider::new();
+
+        let zen_headers = zen.extra_headers("shared-key");
+        let go_headers = go.extra_headers("shared-key");
+
+        // Both providers should generate the same session ID for the same key
+        assert_eq!(zen_headers[0].1, go_headers[0].1);
     }
 }

--- a/crates/server/src/anthropic_oauth.rs
+++ b/crates/server/src/anthropic_oauth.rs
@@ -234,6 +234,7 @@ mod tests {
     fn target(profile: OAuthEgressProfile) -> RoutingTarget {
         RoutingTarget {
             provider_id: "anthropic-oauth".to_string(),
+            vendor: None,
             model_id: "claude-test".to_string(),
             api_base: "https://api.anthropic.com/v1".to_string(),
             api_key: String::new(),

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -576,7 +576,7 @@ pub(super) async fn execute_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -1168,7 +1168,7 @@ pub(super) async fn execute_messages_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -1751,6 +1751,7 @@ pub(super) async fn execute_embeddings_upstream(
     request_id: &str,
     client_headers: &http::HeaderMap,
     cache_key: tiygate_cache::embedding_cache::EmbeddingCacheKey,
+    api_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let (mut upstream_body, mut upstream_headers) =
         codec.encode_request(ir_request).map_err(|e| {
@@ -1766,7 +1767,7 @@ pub(super) async fn execute_embeddings_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
 
     let egress_body_capture = serde_json::to_string(&upstream_body).ok();
     let req_id_capture = request_id.to_string();
@@ -1997,7 +1998,7 @@ pub(super) async fn execute_responses_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -2829,7 +2830,7 @@ pub(super) async fn execute_gemini_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -3311,7 +3312,7 @@ pub(super) async fn execute_images_generations_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
 
     let egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
@@ -3685,7 +3686,7 @@ pub(super) async fn execute_images_edits_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
 
     // TODO(prompt-cache): multipart re-encoding is not implemented in
     // v1, so prompt_cache_key cannot be injected for edits requests.

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -3692,7 +3692,6 @@ pub(super) async fn execute_images_edits_upstream(
     // v1, so prompt_cache_key cannot be injected for edits requests.
     // The virtual→upstream model mapping is also effectively ignored
     // for /v1/images/edits (model override requires multipart parsing).
-    let _ = caller_key_id;
 
     let upstream_url = format!("{}/images/edits", target.effective_api_base());
     let client = &state.tunables().http_client;

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -482,7 +482,7 @@ pub(super) async fn execute_upstream(
     trace: &TraceContext,
     request_id: &str,
     client_headers: &http::HeaderMap,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let egress_protocol = target.api_protocol.clone();
     let is_same_protocol = ingress_protocol.suite == egress_protocol.suite;
@@ -536,7 +536,7 @@ pub(super) async fn execute_upstream(
     // requests from the same caller are routed to the same inference
     // machine, improving prompt-prefix cache hit rates.
     let mut body_mutated =
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
+        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, caller_key_id);
 
     // Replace the (possibly virtual) model name with the routing
     // target's real upstream model id before sending and before we
@@ -576,7 +576,7 @@ pub(super) async fn execute_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -1086,7 +1086,7 @@ pub(super) async fn execute_messages_upstream(
     trace: &TraceContext,
     request_id: &str,
     client_headers: &http::HeaderMap,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let egress_protocol = target.api_protocol.clone();
     let is_same_protocol = ingress_protocol.suite == egress_protocol.suite;
@@ -1133,7 +1133,7 @@ pub(super) async fn execute_messages_upstream(
     // target's real upstream model id.
     let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
     body_mutated |=
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
+        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, caller_key_id);
     body_mutated |= normalize_openai_reasoning_for_target(
         &mut upstream_body,
         &egress_protocol.suite,
@@ -1168,7 +1168,7 @@ pub(super) async fn execute_messages_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -1751,7 +1751,7 @@ pub(super) async fn execute_embeddings_upstream(
     request_id: &str,
     client_headers: &http::HeaderMap,
     cache_key: tiygate_cache::embedding_cache::EmbeddingCacheKey,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let (mut upstream_body, mut upstream_headers) =
         codec.encode_request(ir_request).map_err(|e| {
@@ -1767,7 +1767,7 @@ pub(super) async fn execute_embeddings_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
 
     let egress_body_capture = serde_json::to_string(&upstream_body).ok();
     let req_id_capture = request_id.to_string();
@@ -1930,7 +1930,7 @@ pub(super) async fn execute_responses_upstream(
     trace: &TraceContext,
     request_id: &str,
     client_headers: &http::HeaderMap,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let egress_protocol = target.api_protocol.clone();
     let is_same_protocol = ingress_protocol.suite == egress_protocol.suite;
@@ -1972,7 +1972,7 @@ pub(super) async fn execute_responses_upstream(
 
     let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
     body_mutated |=
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
+        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, caller_key_id);
     body_mutated |= normalize_openai_reasoning_for_target(
         &mut upstream_body,
         &egress_protocol.suite,
@@ -1998,7 +1998,7 @@ pub(super) async fn execute_responses_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -2751,7 +2751,7 @@ pub(super) async fn execute_gemini_upstream(
     trace: &TraceContext,
     request_id: &str,
     client_headers: &http::HeaderMap,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     // Delegate to the shared Responses executor — the only difference is
     // the codec type, and `execute_responses_upstream` already handles
@@ -2804,7 +2804,7 @@ pub(super) async fn execute_gemini_upstream(
 
     let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
     body_mutated |=
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
+        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, caller_key_id);
     body_mutated |= normalize_openai_reasoning_for_target(
         &mut upstream_body,
         &egress_protocol.suite,
@@ -2830,7 +2830,7 @@ pub(super) async fn execute_gemini_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -3264,7 +3264,7 @@ pub(super) async fn execute_images_generations_upstream(
     trace: &TraceContext,
     request_id: &str,
     client_headers: &http::HeaderMap,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let egress_protocol = target.api_protocol.clone();
     let is_same_protocol = ingress_protocol.suite == egress_protocol.suite;
@@ -3302,7 +3302,7 @@ pub(super) async fn execute_images_generations_upstream(
     };
 
     let cache_key_injected =
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
+        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, caller_key_id);
 
     let model_was_overridden = override_model_in_body(&mut upstream_body, &target.model_id);
     let pass_through_verbatim = is_pass_through && !model_was_overridden && !cache_key_injected;
@@ -3312,7 +3312,7 @@ pub(super) async fn execute_images_generations_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
 
     let egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
@@ -3678,7 +3678,7 @@ pub(super) async fn execute_images_edits_upstream(
     trace: &TraceContext,
     request_id: &str,
     client_headers: &http::HeaderMap,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> Result<(Response, Option<u64>), AppError> {
     let mut upstream_headers = http::HeaderMap::new();
     merge_client_headers(
@@ -3686,13 +3686,13 @@ pub(super) async fn execute_images_edits_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, api_key_id).await?;
+    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
 
     // TODO(prompt-cache): multipart re-encoding is not implemented in
     // v1, so prompt_cache_key cannot be injected for edits requests.
     // The virtual→upstream model mapping is also effectively ignored
     // for /v1/images/edits (model override requires multipart parsing).
-    let _ = api_key_id;
+    let _ = caller_key_id;
 
     let upstream_url = format!("{}/images/edits", target.effective_api_base());
     let client = &state.tunables().http_client;

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -576,7 +576,13 @@ pub(super) async fn execute_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -1168,7 +1174,13 @@ pub(super) async fn execute_messages_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -1767,7 +1779,13 @@ pub(super) async fn execute_embeddings_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
 
     let egress_body_capture = serde_json::to_string(&upstream_body).ok();
     let req_id_capture = request_id.to_string();
@@ -1998,7 +2016,13 @@ pub(super) async fn execute_responses_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -2830,7 +2854,13 @@ pub(super) async fn execute_gemini_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
     if openai_codex_profile {
         codex_oauth::apply_request_headers(
             &mut upstream_headers,
@@ -3312,7 +3342,13 @@ pub(super) async fn execute_images_generations_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
 
     let egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
@@ -3686,7 +3722,13 @@ pub(super) async fn execute_images_edits_upstream(
         &mut upstream_headers,
         &state.tunables().header_policy,
     );
-    apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager, caller_key_id).await?;
+    apply_provider_auth(
+        target,
+        &mut upstream_headers,
+        &state.oauth_manager,
+        caller_key_id,
+    )
+    .await?;
 
     // TODO(prompt-cache): multipart re-encoding is not implemented in
     // v1, so prompt_cache_key cannot be injected for edits requests.

--- a/crates/server/src/ingress/handlers.rs
+++ b/crates/server/src/ingress/handlers.rs
@@ -351,7 +351,7 @@ pub(super) async fn handle_chat_completions(
     // resolved `api_key` is bound to the scope so the terminal
     // RequestEvent attributes the row to the right caller.
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));
@@ -507,7 +507,7 @@ pub(super) async fn handle_messages(
     // bound to the scope so the terminal `RequestEvent` attributes
     // the row to the right caller.
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));
@@ -653,7 +653,7 @@ pub(super) async fn handle_embeddings(
     // requests count against the same `requests_per_minute` /
     // `requests_per_day` bucket as chat completions.
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));
@@ -856,7 +856,7 @@ pub(super) async fn handle_responses(
     // Bind the api key id so the terminal RequestEvent attributes the
     // row to the right caller (used by the per-key quota dashboard).
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));
@@ -1027,7 +1027,7 @@ pub(super) async fn handle_gemini_generate(
     // Bind the api key id so the terminal RequestEvent attributes the
     // row to the right caller (used by the per-key quota dashboard).
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));
@@ -1180,7 +1180,7 @@ pub(super) async fn handle_images_generations(
         enforce_body_limit_or_log(&state, scope, content_type, body_size, codec.id().suite)?;
 
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));
@@ -1384,7 +1384,7 @@ pub(super) async fn handle_images_edits(
     )?;
 
     let api_key = crate::ingress::observability::resolve_api_key(&state, &headers).await;
-    scope.set_api_key_id(api_key.key_id.clone());
+    scope.set_caller_key_id(api_key.key_id.clone());
     if let Err((err, class)) = crate::ingress::observability::enforce_auth(&state, &api_key) {
         scope.emit_error(class, Some(&err.message), Some(err.http_status().as_u16()));
         return Err(err.with_protocol_suite(codec.id().suite));

--- a/crates/server/src/ingress/handlers.rs
+++ b/crates/server/src/ingress/handlers.rs
@@ -773,6 +773,7 @@ pub(super) async fn handle_embeddings(
                 &request_id,
                 &headers,
                 cache_key,
+                &api_key.key_id,
             ))
         },
     )

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -254,15 +254,15 @@ pub(super) fn extract_rate_limit_headers(headers: &HeaderMap) -> Vec<(&'static s
 ///
 /// Some providers require custom headers (e.g. OpenCode requires
 /// `x-opencode-session`) that clients don't know about. The provider
-/// generates these based on the upstream API key. This function is
-/// called *after* `apply_provider_auth` so provider auth headers
+/// generates these based on the caller's TiyGate key ID. This function
+/// is called *after* `apply_provider_auth` so provider auth headers
 /// always win.
 pub(super) fn inject_provider_extra_headers(
     provider: &dyn tiygate_core::Provider,
-    api_key: &str,
+    caller_key_id: &str,
     upstream: &mut http::HeaderMap,
 ) {
-    for (name, value) in provider.extra_headers(api_key) {
+    for (name, value) in provider.extra_headers(caller_key_id) {
         if let (Ok(hn), Ok(hv)) = (
             http::HeaderName::from_bytes(name.as_bytes()),
             http::HeaderValue::from_str(&value),
@@ -329,8 +329,8 @@ mod tests {
             fn metadata(&self) -> &ProviderMetadata { unreachable!() }
             fn supported_protocols(&self) -> &[ProtocolEndpoint] { unreachable!() }
             fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> { unreachable!() }
-            fn extra_headers(&self, api_key: &str) -> Vec<(&'static str, String)> {
-                vec![("x-test-header", format!("session-{api_key}"))]
+            fn extra_headers(&self, caller_key_id: &str) -> Vec<(&'static str, String)> {
+                vec![("x-test-header", format!("session-{caller_key_id}"))]
             }
         }
 

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -250,6 +250,28 @@ pub(super) fn extract_rate_limit_headers(headers: &HeaderMap) -> Vec<(&'static s
     out
 }
 
+/// Inject provider-specific extra headers into the upstream request.
+///
+/// Some providers require custom headers (e.g. OpenCode requires
+/// `x-opencode-session`) that clients don't know about. The provider
+/// generates these based on the upstream API key. This function is
+/// called *after* `apply_provider_auth` so provider auth headers
+/// always win.
+pub(super) fn inject_provider_extra_headers(
+    provider: &dyn tiygate_core::Provider,
+    api_key: &str,
+    upstream: &mut http::HeaderMap,
+) {
+    for (name, value) in provider.extra_headers(api_key) {
+        if let (Ok(hn), Ok(hv)) = (
+            http::HeaderName::from_bytes(name.as_bytes()),
+            http::HeaderValue::from_str(&value),
+        ) {
+            upstream.insert(hn, hv);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -294,5 +316,51 @@ mod tests {
             &tiygate_core::ProtocolSuite::OpenAiResponses,
             "other"
         ));
+    }
+
+    #[test]
+    fn inject_provider_extra_headers_adds_headers() {
+        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
+        use std::sync::Arc;
+
+        struct TestProvider;
+        impl Provider for TestProvider {
+            fn id(&self) -> &str { "test" }
+            fn metadata(&self) -> &ProviderMetadata { unreachable!() }
+            fn supported_protocols(&self) -> &[ProtocolEndpoint] { unreachable!() }
+            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> { unreachable!() }
+            fn extra_headers(&self, api_key: &str) -> Vec<(&'static str, String)> {
+                vec![("x-test-header", format!("session-{api_key}"))]
+            }
+        }
+
+        let provider = TestProvider;
+        let mut headers = http::HeaderMap::new();
+        inject_provider_extra_headers(&provider, "my-key", &mut headers);
+
+        assert_eq!(
+            headers.get("x-test-header").unwrap().to_str().unwrap(),
+            "session-my-key"
+        );
+    }
+
+    #[test]
+    fn inject_provider_extra_headers_empty_by_default() {
+        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
+        use std::sync::Arc;
+
+        struct DefaultProvider;
+        impl Provider for DefaultProvider {
+            fn id(&self) -> &str { "default" }
+            fn metadata(&self) -> &ProviderMetadata { unreachable!() }
+            fn supported_protocols(&self) -> &[ProtocolEndpoint] { unreachable!() }
+            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> { unreachable!() }
+        }
+
+        let provider = DefaultProvider;
+        let mut headers = http::HeaderMap::new();
+        inject_provider_extra_headers(&provider, "any-key", &mut headers);
+
+        assert!(headers.is_empty());
     }
 }

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -161,7 +161,7 @@ pub(super) fn spawn_capture(state: &AppState, capture: tiygate_core::ExchangeCap
 pub(super) fn maybe_inject_prompt_cache_key(
     body: &mut serde_json::Value,
     egress_suite: &tiygate_core::ProtocolSuite,
-    api_key_id: &str,
+    caller_key_id: &str,
 ) -> bool {
     let dominated_by_openai = matches!(
         egress_suite,
@@ -176,10 +176,10 @@ pub(super) fn maybe_inject_prompt_cache_key(
         return false;
     }
     // "anonymous" callers have no stable identity → skip injection.
-    if api_key_id == "anonymous" {
+    if caller_key_id == "anonymous" {
         return false;
     }
-    body["prompt_cache_key"] = serde_json::Value::String(api_key_id.to_string());
+    body["prompt_cache_key"] = serde_json::Value::String(caller_key_id.to_string());
     true
 }
 

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -262,12 +262,25 @@ pub(super) fn inject_provider_extra_headers(
     caller_key_id: &str,
     upstream: &mut http::HeaderMap,
 ) {
-    for (name, value) in provider.extra_headers(caller_key_id) {
+    // When there is no real caller identity (anonymous / empty key),
+    // still inject the header — OpenCode requires it — but use a
+    // fixed sentinel so all anonymous callers share one session
+    // rather than each producing a different hash of "".
+    let effective_key = if caller_key_id.is_empty() || caller_key_id == "anonymous" {
+        "tiygate-anonymous"
+    } else {
+        caller_key_id
+    };
+    for (name, value) in provider.extra_headers(effective_key) {
         if let (Ok(hn), Ok(hv)) = (
             http::HeaderName::from_bytes(name.as_bytes()),
             http::HeaderValue::from_str(&value),
         ) {
-            upstream.insert(hn, hv);
+            // Use entry() to preserve client-provided headers — only
+            // insert when the header is not already present.  This
+            // respects a valid session ID supplied by the client and
+            // prevents extra_headers from overwriting auth headers.
+            upstream.entry(hn).or_insert(hv);
         }
     }
 }
@@ -320,15 +333,23 @@ mod tests {
 
     #[test]
     fn inject_provider_extra_headers_adds_headers() {
-        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
         use std::sync::Arc;
+        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
 
         struct TestProvider;
         impl Provider for TestProvider {
-            fn id(&self) -> &str { "test" }
-            fn metadata(&self) -> &ProviderMetadata { unreachable!() }
-            fn supported_protocols(&self) -> &[ProtocolEndpoint] { unreachable!() }
-            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> { unreachable!() }
+            fn id(&self) -> &str {
+                "test"
+            }
+            fn metadata(&self) -> &ProviderMetadata {
+                unreachable!()
+            }
+            fn supported_protocols(&self) -> &[ProtocolEndpoint] {
+                unreachable!()
+            }
+            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> {
+                unreachable!()
+            }
             fn extra_headers(&self, caller_key_id: &str) -> Vec<(&'static str, String)> {
                 vec![("x-test-header", format!("session-{caller_key_id}"))]
             }
@@ -346,15 +367,23 @@ mod tests {
 
     #[test]
     fn inject_provider_extra_headers_empty_by_default() {
-        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
         use std::sync::Arc;
+        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
 
         struct DefaultProvider;
         impl Provider for DefaultProvider {
-            fn id(&self) -> &str { "default" }
-            fn metadata(&self) -> &ProviderMetadata { unreachable!() }
-            fn supported_protocols(&self) -> &[ProtocolEndpoint] { unreachable!() }
-            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> { unreachable!() }
+            fn id(&self) -> &str {
+                "default"
+            }
+            fn metadata(&self) -> &ProviderMetadata {
+                unreachable!()
+            }
+            fn supported_protocols(&self) -> &[ProtocolEndpoint] {
+                unreachable!()
+            }
+            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> {
+                unreachable!()
+            }
         }
 
         let provider = DefaultProvider;
@@ -362,5 +391,91 @@ mod tests {
         inject_provider_extra_headers(&provider, "any-key", &mut headers);
 
         assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn inject_provider_extra_headers_preserves_client_header() {
+        use std::sync::Arc;
+        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
+
+        struct TestProvider;
+        impl Provider for TestProvider {
+            fn id(&self) -> &str {
+                "test"
+            }
+            fn metadata(&self) -> &ProviderMetadata {
+                unreachable!()
+            }
+            fn supported_protocols(&self) -> &[ProtocolEndpoint] {
+                unreachable!()
+            }
+            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> {
+                unreachable!()
+            }
+            fn extra_headers(&self, caller_key_id: &str) -> Vec<(&'static str, String)> {
+                vec![("x-opencode-session", format!("generated-{caller_key_id}"))]
+            }
+        }
+
+        let provider = TestProvider;
+        let mut headers = http::HeaderMap::new();
+        // Client already provided a session header
+        headers.insert(
+            http::HeaderName::from_static("x-opencode-session"),
+            http::HeaderValue::from_static("client-existing-session"),
+        );
+
+        inject_provider_extra_headers(&provider, "my-key", &mut headers);
+
+        // Client value should be preserved, not overwritten
+        assert_eq!(
+            headers.get("x-opencode-session").unwrap().to_str().unwrap(),
+            "client-existing-session"
+        );
+    }
+
+    #[test]
+    fn inject_provider_extra_headers_uses_default_for_anonymous() {
+        use std::sync::Arc;
+        use tiygate_core::{ProtocolEndpoint, Provider, ProviderMetadata};
+
+        struct TestProvider;
+        impl Provider for TestProvider {
+            fn id(&self) -> &str {
+                "test"
+            }
+            fn metadata(&self) -> &ProviderMetadata {
+                unreachable!()
+            }
+            fn supported_protocols(&self) -> &[ProtocolEndpoint] {
+                unreachable!()
+            }
+            fn auth(&self) -> Arc<dyn tiygate_core::AuthApplier> {
+                unreachable!()
+            }
+            fn extra_headers(&self, caller_key_id: &str) -> Vec<(&'static str, String)> {
+                vec![("x-opencode-session", format!("session-{caller_key_id}"))]
+            }
+        }
+
+        let provider = TestProvider;
+
+        // Empty key → uses "tiygate-anonymous" sentinel
+        let mut headers = http::HeaderMap::new();
+        inject_provider_extra_headers(&provider, "", &mut headers);
+        let val = headers.get("x-opencode-session").unwrap().to_str().unwrap();
+        assert_eq!(val, "session-tiygate-anonymous");
+
+        // "anonymous" key → same sentinel
+        let mut headers = http::HeaderMap::new();
+        inject_provider_extra_headers(&provider, "anonymous", &mut headers);
+        let val = headers.get("x-opencode-session").unwrap().to_str().unwrap();
+        assert_eq!(val, "session-tiygate-anonymous");
+
+        // Real key → uses the actual key
+        let mut headers = http::HeaderMap::new();
+        inject_provider_extra_headers(&provider, "real-key-123", &mut headers);
+        let val = headers.get("x-opencode-session").unwrap().to_str().unwrap();
+        assert_eq!(val, "session-real-key-123");
     }
 }

--- a/crates/server/src/ingress/mod.rs
+++ b/crates/server/src/ingress/mod.rs
@@ -807,6 +807,11 @@ pub fn compute_pass_through<C: tiygate_core::EndpointCodec>(
 /// a caller substitute a different upstream key than the one
 /// TiyGate routes traffic to, breaking per-account model routing
 /// and the audit trail.
+///
+/// `caller_key_id` is the caller's TiyGate API key ID. It is passed
+/// to provider `extra_headers()` so providers can derive stable
+/// per-customer session identifiers (e.g. OpenCode's
+/// `x-opencode-session`).
 pub async fn apply_provider_auth(
     target: &tiygate_core::RoutingTarget,
     upstream_headers: &mut http::HeaderMap,

--- a/crates/server/src/ingress/mod.rs
+++ b/crates/server/src/ingress/mod.rs
@@ -811,6 +811,7 @@ pub async fn apply_provider_auth(
     target: &tiygate_core::RoutingTarget,
     upstream_headers: &mut http::HeaderMap,
     oauth_manager: &crate::oauth_manager::OAuthTokenManager,
+    caller_key_id: &str,
 ) -> Result<(), AppError> {
     // OAuth path: if the routing target carries an OAuth config,
     // use the OAuthTokenManager to refresh/inject the access token.
@@ -840,8 +841,9 @@ pub async fn apply_provider_auth(
         }
         // Inject provider-specific extra headers (e.g. x-opencode-session)
         // after auth so provider auth headers always win.
-        let api_key = target.effective_api_key().to_string();
-        inject_provider_extra_headers(&*provider, &api_key, upstream_headers);
+        // Use caller_key_id (TiYgate customer's key) so each customer
+        // gets a unique session identifier, not the shared upstream key.
+        inject_provider_extra_headers(&*provider, caller_key_id, upstream_headers);
         return Ok(());
     }
     // Protocol-aware fallback when no provider is registered for the

--- a/crates/server/src/ingress/mod.rs
+++ b/crates/server/src/ingress/mod.rs
@@ -36,6 +36,8 @@ use tower_http::timeout::RequestBodyTimeoutLayer;
 
 use tiygate_core::{HealthRegistry, TelemetryBus};
 
+use headers::inject_provider_extra_headers;
+
 /// Construct a `Strategy` from the `RoutingStrategyName` carried on
 /// `AppState`. §3.4 names `Weighted` as the document-level default; we honor
 /// that here. The `Latency` strategy needs the `HealthRegistry` handle, so it
@@ -825,7 +827,10 @@ pub async fn apply_provider_auth(
         }
     }
 
-    if let Some(provider) = tiygate_core::provider::find_provider(&target.provider_id) {
+    // Use vendor (if available) for registered-provider lookup, falling back
+    // to provider_id for legacy targets that predate the vendor field.
+    let lookup_key = target.vendor.as_deref().unwrap_or(&target.provider_id);
+    if let Some(provider) = tiygate_core::provider::find_provider(lookup_key) {
         let auth = provider.auth();
         if let Err(e) = auth.apply(upstream_headers, target).await {
             return Err(AppError::new(
@@ -833,6 +838,10 @@ pub async fn apply_provider_auth(
                 format!("Provider auth applier failed: {e}"),
             ));
         }
+        // Inject provider-specific extra headers (e.g. x-opencode-session)
+        // after auth so provider auth headers always win.
+        let api_key = target.effective_api_key().to_string();
+        inject_provider_extra_headers(&*provider, &api_key, upstream_headers);
         return Ok(());
     }
     // Protocol-aware fallback when no provider is registered for the

--- a/crates/server/src/ingress/mod.rs
+++ b/crates/server/src/ingress/mod.rs
@@ -823,7 +823,16 @@ pub async fn apply_provider_auth(
     // Return immediately on success; fall through to the static
     // key path only when the target is not OAuth-mode.
     match oauth_manager.apply(target, upstream_headers).await {
-        Ok(true) => return Ok(()),
+        Ok(true) => {
+            // OAuth succeeded — still inject provider-specific extra
+            // headers (e.g. x-opencode-session) so the trait contract
+            // is consistent across auth paths.
+            let lookup_key = target.vendor.as_deref().unwrap_or(&target.provider_id);
+            if let Some(provider) = tiygate_core::provider::find_provider(lookup_key) {
+                inject_provider_extra_headers(&*provider, caller_key_id, upstream_headers);
+            }
+            return Ok(());
+        }
         Ok(false) => { /* not OAuth — fall through to static key */ }
         Err(e) => {
             return Err(AppError::new(

--- a/crates/server/src/ingress/observability.rs
+++ b/crates/server/src/ingress/observability.rs
@@ -322,11 +322,11 @@ pub(super) struct RequestScope<'a> {
     resolved_model: Option<String>,
     trace: TraceContext,
     started: Instant,
-    /// Resolved api key id from `resolve_api_key` (`"anonymous"` when
-    /// no credential was supplied). Surface this on the terminal
+    /// Resolved caller key id from `resolve_api_key` (`"anonymous"`
+    /// when no credential was supplied). Surface this on the terminal
     /// `RequestEvent` so the OltpSink can attribute the row to a
     /// specific key — required for the per-key quota dashboard.
-    api_key_id: String,
+    caller_key_id: String,
     /// Optional `RawEnvelope` captured at the ingress. Set via
     /// `set_envelope` and persisted on the terminal `RequestEvent`
     /// so the OLTP log row carries the redacted envelope for
@@ -368,7 +368,7 @@ impl<'a> RequestScope<'a> {
             resolved_model: None,
             trace,
             started,
-            api_key_id: "anonymous".to_string(),
+            caller_key_id: "anonymous".to_string(),
             envelope: None,
             ttfb_ms: None,
             armed: true,
@@ -389,10 +389,10 @@ impl<'a> RequestScope<'a> {
         self.resolved_model = Some(model);
     }
 
-    /// Bind the resolved api key id. Call after `resolve_api_key` at
-    /// the top of the handler.
-    pub fn set_api_key_id(&mut self, key_id: String) {
-        self.api_key_id = key_id;
+    /// Bind the resolved caller key id. Call after `resolve_api_key`
+    /// at the top of the handler.
+    pub fn set_caller_key_id(&mut self, key_id: String) {
+        self.caller_key_id = key_id;
     }
 
     /// Bind the `RawEnvelope` so the terminal `RequestEvent`
@@ -502,7 +502,7 @@ impl<'a> RequestScope<'a> {
             },
             self.ttfb_ms,
             None,
-            Some(&self.api_key_id),
+            Some(&self.caller_key_id),
             &self.trace,
             envelope,
         );
@@ -560,7 +560,7 @@ impl<'a> Drop for RequestScope<'a> {
             latency_ms,
             self.ttfb_ms,
             None,
-            Some(&self.api_key_id),
+            Some(&self.caller_key_id),
             &self.trace,
             self.envelope.as_ref(),
         );
@@ -864,14 +864,14 @@ pub(super) fn finalize_egress(
 /// `1` for request-level counters.
 pub(super) async fn check_quota(
     state: &AppState,
-    api_key_id: &str,
+    caller_key_id: &str,
     spec: &QuotaSpec,
     tokens: u64,
 ) -> QuotaOutcome {
     let Some(q) = state.quota.as_ref() else {
         return QuotaOutcome::Allow;
     };
-    match q.check_and_consume(api_key_id, spec, tokens).await {
+    match q.check_and_consume(caller_key_id, spec, tokens).await {
         Ok(QuotaDecision::Allow { .. }) => QuotaOutcome::Allow,
         Ok(QuotaDecision::Deny {
             retry_after,
@@ -964,7 +964,7 @@ pub(super) fn emit_request_event(
     latency: LatencyBreakdown,
     ttfb_ms: Option<u64>,
     tokens: Option<Usage>,
-    api_key_id: Option<&str>,
+    caller_key_id: Option<&str>,
     trace: &TraceContext,
     envelope: Option<&RawEnvelope>,
 ) {
@@ -995,7 +995,7 @@ pub(super) fn emit_request_event(
         ttfb_ms,
         tokens: tokens.clone(),
         cost: None,
-        api_key_id: api_key_id.map(str::to_string),
+        api_key_id: caller_key_id.map(str::to_string),
         client_ip: None,
         user_agent: None,
         // Persist the redacted envelope alongside the
@@ -1021,7 +1021,7 @@ pub(super) fn emit_request_event(
             ttfb_ms,
             tokens,
             cost: None,
-            api_key_id: api_key_id.map(str::to_string),
+            api_key_id: caller_key_id.map(str::to_string),
             client_ip: None,
             user_agent: None,
             trace_id: Some(trace.trace_id.clone()),
@@ -1073,7 +1073,7 @@ pub(super) fn emit_completion(
     error_class: Option<RequestErrorClass>,
     http_status: Option<u16>,
     trace: &TraceContext,
-    api_key_id: Option<&str>,
+    caller_key_id: Option<&str>,
     started: Instant,
     envelope: Option<&RawEnvelope>,
 ) {
@@ -1099,7 +1099,7 @@ pub(super) fn emit_completion(
         latency_ms,
         None,
         None,
-        api_key_id,
+        caller_key_id,
         trace,
         envelope,
     );

--- a/crates/server/src/oauth_manager.rs
+++ b/crates/server/src/oauth_manager.rs
@@ -1106,6 +1106,7 @@ mod tests {
     fn make_target(oauth: Option<OAuthTargetConfig>) -> RoutingTarget {
         RoutingTarget {
             provider_id: "test-prov".to_string(),
+            vendor: None,
             model_id: "test-model".to_string(),
             api_base: String::new(),
             api_key: String::new(),
@@ -1272,6 +1273,7 @@ mod tests {
         let oauth = build_oauth_target_config(&provider).unwrap();
         let target = RoutingTarget {
             provider_id: provider_id.to_string(),
+            vendor: None,
             model_id: "model".to_string(),
             api_base: String::new(),
             api_key: String::new(),
@@ -2009,6 +2011,7 @@ mod tests {
         let provider = store_a.get_provider(&provider_id).await.unwrap().unwrap();
         let target = RoutingTarget {
             provider_id: provider_id.clone(),
+            vendor: None,
             model_id: "model".to_string(),
             api_base: String::new(),
             api_key: String::new(),

--- a/crates/server/src/openai_codex_oauth.rs
+++ b/crates/server/src/openai_codex_oauth.rs
@@ -734,6 +734,7 @@ mod tests {
     fn target(profile: OAuthEgressProfile, transport: UpstreamTransport) -> RoutingTarget {
         RoutingTarget {
             provider_id: "openai-oauth".to_string(),
+            vendor: None,
             model_id: "gpt-test".to_string(),
             api_base: "https://chatgpt.com/backend-api/codex".to_string(),
             api_key: String::new(),

--- a/crates/server/tests/models_catalog.rs
+++ b/crates/server/tests/models_catalog.rs
@@ -40,6 +40,7 @@ async fn models_endpoint_enriches_visible_routes_from_catalog() {
     routing_table.insert(
         "zai/glm-test".to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "zai".to_string(),
             model_id: "zai/glm-test".to_string(),
             api_base: "https://example.invalid/v1".to_string(),

--- a/crates/server/tests/redirect_auth.rs
+++ b/crates/server/tests/redirect_auth.rs
@@ -40,6 +40,7 @@ fn build_test_app(upstream_url: String, model: &str) -> axum::Router {
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,

--- a/crates/server/tests/wiremock_images.rs
+++ b/crates/server/tests/wiremock_images.rs
@@ -38,6 +38,7 @@ fn build_images_test_app(
     routing_table.insert(
         virtual_model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: upstream_model.to_string(),
             api_base: upstream_url,

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -53,6 +53,7 @@ fn build_test_app_with_config(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,
@@ -92,6 +93,7 @@ fn build_anthropic_test_app_with_config(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "anthropic".to_string(),
             model_id: "claude-3-5-sonnet-20241022".to_string(),
             api_base: upstream_url,
@@ -126,6 +128,7 @@ fn build_anthropic_ingress_codex_egress_app(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: provider_id.to_string(),
             model_id: model.to_string(),
             api_base: upstream_url,
@@ -169,6 +172,7 @@ fn build_openai_compatible_test_app(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai-compatible".to_string(),
             model_id: model.to_string(),
             api_base: upstream_url,
@@ -809,7 +813,7 @@ async fn test_multi_target_fallback_5xx_transfers() {
         "gpt-4o".to_string(),
         vec![
             tiygate_core::RoutingTarget {
-                provider_id: "primary".to_string(),
+            vendor: None,                 provider_id: "primary".to_string(),
                 model_id: "gpt-4o".to_string(),
                 api_base: primary.uri(),
                 api_key: "sk-1".to_string(),
@@ -825,7 +829,7 @@ async fn test_multi_target_fallback_5xx_transfers() {
                 oauth: None,
             },
             tiygate_core::RoutingTarget {
-                provider_id: "secondary".to_string(),
+            vendor: None,                 provider_id: "secondary".to_string(),
                 model_id: "gpt-4o".to_string(),
                 api_base: secondary.uri(),
                 api_key: "sk-2".to_string(),
@@ -1245,6 +1249,7 @@ fn build_chat_ingress_anthropic_egress_app(upstream_url: String, model: &str) ->
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "anthropic".to_string(),
             model_id: "claude-3-5-sonnet-20241022".to_string(),
             api_base: upstream_url,
@@ -1277,6 +1282,7 @@ fn build_messages_ingress_openai_egress_app(upstream_url: String, model: &str) -
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,
@@ -1554,6 +1560,7 @@ fn build_chat_ingress_anthropic_egress_app_with_config(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "anthropic".to_string(),
             model_id: "claude-3-5-sonnet-20241022".to_string(),
             api_base: upstream_url,
@@ -1733,6 +1740,7 @@ fn build_responses_ingress_openai_egress_app_with_config(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,
@@ -1773,6 +1781,7 @@ fn build_gemini_ingress_openai_egress_app_with_config(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,
@@ -2010,6 +2019,7 @@ fn build_responses_same_protocol_app(upstream_url: String, model: &str) -> axum:
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,
@@ -2037,6 +2047,7 @@ fn build_gemini_same_protocol_app(upstream_url: String, model: &str) -> axum::Ro
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "google".to_string(),
             model_id: "gemini-pro".to_string(),
             api_base: upstream_url,
@@ -2166,6 +2177,7 @@ fn build_app_with_require_api_key(
     routing_table.insert(
         model.to_string(),
         vec![tiygate_core::RoutingTarget {
+            vendor: None,
             provider_id: "openai".to_string(),
             model_id: "gpt-4o".to_string(),
             api_base: upstream_url,

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -813,7 +813,8 @@ async fn test_multi_target_fallback_5xx_transfers() {
         "gpt-4o".to_string(),
         vec![
             tiygate_core::RoutingTarget {
-            vendor: None,                 provider_id: "primary".to_string(),
+                vendor: None,
+                provider_id: "primary".to_string(),
                 model_id: "gpt-4o".to_string(),
                 api_base: primary.uri(),
                 api_key: "sk-1".to_string(),
@@ -829,7 +830,8 @@ async fn test_multi_target_fallback_5xx_transfers() {
                 oauth: None,
             },
             tiygate_core::RoutingTarget {
-            vendor: None,                 provider_id: "secondary".to_string(),
+                vendor: None,
+                provider_id: "secondary".to_string(),
                 model_id: "gpt-4o".to_string(),
                 api_base: secondary.uri(),
                 api_key: "sk-2".to_string(),

--- a/crates/store/src/config_store.rs
+++ b/crates/store/src/config_store.rs
@@ -120,6 +120,7 @@ impl ConfigStore {
         if let Ok(key) = std::env::var("OPENAI_API_KEY") {
             let openai_targets = vec![RoutingTarget {
                 provider_id: "openai".to_string(),
+                vendor: None,
                 model_id: "gpt-4o".to_string(),
                 api_base: "https://api.openai.com/v1".to_string(),
                 api_key: key.clone(),
@@ -151,6 +152,7 @@ impl ConfigStore {
         if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
             let anthropic_targets = vec![RoutingTarget {
                 provider_id: "anthropic".to_string(),
+                vendor: None,
                 model_id: "claude-sonnet-4-20250514".to_string(),
                 api_base: "https://api.anthropic.com/v1".to_string(),
                 api_key: key.clone(),
@@ -305,6 +307,7 @@ pub fn snapshot_to_routing_table(snapshot: &ConfigSnapshot) -> RoutingTable {
                 provider_egress_for_target(provider, &t.model_id, &raw_base);
             targets.push(RoutingTarget {
                 provider_id: provider.id.clone(),
+                vendor: Some(provider.vendor.clone()),
                 model_id: t.model_id.clone(),
                 api_base,
                 api_key,


### PR DESCRIPTION
## Motivation

OpenCode.ai requires an x-opencode-session header to identify requests from the same user session. Starting 09/06 requests missing this header may error. This change lets TiYgate generate the header centrally so clients don't need modification.

## Changes

- Add extra_headers(api_key: &str) -> Vec<(&'static str, String)> to the Provider trait (default returns empty vec)
- OpenCodeZenProvider and OpenCodeGoProvider override extra_headers to return x-opencode-session = SHA256(caller_key_id)
- Add vendor field to RoutingTarget for provider lookup (fixes find_provider() which uses vendor name, not DB UUID)
- apply_provider_auth takes caller_key_id parameter and passes it to inject_provider_extra_headers
- Header injection happens after apply_provider_auth so provider auth headers always win

## Key design decision

Session ID is derived from the caller's TiYgate API key ID, not the upstream provider key. This ensures each TiYgate customer gets a unique, stable session identifier — different customers sharing the same route produce different x-opencode-session values.

## Testing

- Unit tests: 170/170 passing
- E2E: capture server verified x-opencode-session header present with correct SHA256 format
- All existing integration tests pass

---
