### PR TITLE
fix(desktop): 🐛 Prevent Windows setup loops and duplicate instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5822,6 +5838,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [ "tray-icon", "image-png"] }
+tauri-plugin-single-instance = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-opener = "2"
 serde = { workspace = true }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -438,11 +438,7 @@ async fn restart_with_current_config(
             .path()
             .app_local_data_dir()
             .map_err(|e| format!("failed to resolve app_local_data_dir: {e}"))?;
-        let db_path = data_dir.join("tiygate.db");
-        let db_url = format!(
-            "sqlite://{}?mode=rwc",
-            db_path.to_string_lossy().replace('\\', "/")
-        );
+        let db_url = sidecar::sqlite_database_url(&data_dir);
         (
             port,
             cfg.admin_token.clone(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,15 @@ pub fn run() {
     app_start_time();
 
     let app = match tauri::Builder::default()
+        // The desktop client owns one local SQLite database and one sidecar.
+        // A second launch must therefore wake the existing process instead of
+        // starting another sidecar against the same files on the next port.
+        // Register this first so it can intercept secondary launches before
+        // any other plugin performs initialization.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            tracing::info!("secondary TiyGate launch requested; showing existing window");
+            show_main_window(app);
+        }))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
@@ -82,16 +91,7 @@ pub fn run() {
             let port = sidecar::find_available_port(13000)
                 .ok_or_else(|| anyhow::anyhow!("no available port in range 13000-13099"))?;
 
-            let db_path = data_dir.join("tiygate.db");
-            // Use `sqlite:` (not `sqlite://`) so the URL parser does not
-            // treat a Windows drive letter (e.g. `C:`) as the host part
-            // of an authority. With `sqlite://C:/…` the `url` crate
-            // parses `C` as host and strips it, leaving a relative path
-            // that SQLite cannot open. `sqlite:` keeps the path verbatim.
-            let db_url = format!(
-                "sqlite:{}?mode=rwc",
-                db_path.to_string_lossy().replace('\\', "/")
-            );
+            let db_url = sidecar::sqlite_database_url(&data_dir);
 
             // Use the admin token already stored in the config (generated
             // during load_or_init when missing). The sidecar inherits it
@@ -293,6 +293,10 @@ fn show_main_window(app: &tauri::AppHandle) {
     if let Err(e) = window.show() {
         tracing::warn!("failed to show main window: {e}");
         return;
+    }
+
+    if let Err(e) = window.unminimize() {
+        tracing::warn!("failed to restore minimized main window: {e}");
     }
 
     if let Err(e) = window.set_focus() {

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -10,6 +10,7 @@
 //! - Graceful shutdown: kill the child process and wait for exit.
 
 use std::net::TcpListener;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -23,6 +24,20 @@ const MAX_PORT_ATTEMPTS: u16 = 100;
 /// How long to wait for the sidecar health check to succeed.
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(300);
+
+/// Build the SQLite URL shared by initial startup and every sidecar restart.
+///
+/// `sqlite:` is intentional: `sqlite://C:/...` treats the Windows drive
+/// letter as a URL authority and leaves SQLite with an invalid relative path.
+/// Keeping this in one helper prevents the startup and restart paths from
+/// drifting apart again.
+pub fn sqlite_database_url(data_dir: &Path) -> String {
+    let db_path = data_dir.join("tiygate.db");
+    format!(
+        "sqlite:{}?mode=rwc",
+        db_path.to_string_lossy().replace('\\', "/")
+    )
+}
 
 /// Wrapper around the spawned sidecar child process.
 pub struct SidecarManager {
@@ -84,7 +99,7 @@ pub fn find_available_port(start_port: u16) -> Option<u16> {
 /// * `port` - Port for the sidecar to listen on.
 /// * `admin_token` - Value for `TIYGATE_ADMIN_TOKEN`.
 /// * `master_key` - 64-char hex for `TIYGATE_MASTER_KEY`.
-/// * `db_url` - SQLite database URL (e.g. `sqlite:///path/to/tiygate.db?mode=rwc`).
+/// * `db_url` - SQLite database URL (e.g. `sqlite:/path/to/tiygate.db?mode=rwc`).
 pub async fn spawn_sidecar(
     app: &AppHandle,
     port: u16,
@@ -212,6 +227,24 @@ async fn wait_for_health(port: u16) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sqlite_database_url_preserves_windows_drive_letter() {
+        let url = sqlite_database_url(Path::new(r"C:\Users\test\AppData\Local\TiyGate"));
+        assert_eq!(
+            url,
+            "sqlite:C:/Users/test/AppData/Local/TiyGate/tiygate.db?mode=rwc"
+        );
+        assert!(!url.starts_with("sqlite://C:"));
+    }
+
+    #[test]
+    fn sqlite_database_url_builds_unix_absolute_path() {
+        assert_eq!(
+            sqlite_database_url(Path::new("/var/lib/tiygate")),
+            "sqlite:/var/lib/tiygate/tiygate.db?mode=rwc"
+        );
+    }
 
     #[test]
     fn find_available_port_returns_a_bindable_port() {

--- a/webui/src/pages/Setup.tsx
+++ b/webui/src/pages/Setup.tsx
@@ -650,6 +650,7 @@ export default function Setup() {
           {mode === "show-master-key" && (
             <div className="space-y-4">
               <Alert tone="warning">{t("setup.masterKeyWarning")}</Alert>
+              {error ? <ErrorBox message={error} /> : null}
               <div>
                 <label className="mb-1 block text-sm font-medium text-text">
                   {t("setup.masterKeyLabel")}


### PR DESCRIPTION
## Summary
- Use one SQLite URL builder for initial startup and sidecar restarts so Windows drive-letter paths remain valid.
- Enforce a single desktop process and restore the existing window when TiyGate is launched again.
- Surface sidecar restart failures during master-key setup and add Windows/Unix URL regression coverage.

## Test Plan
- [x] `cargo check -p tiygate-desktop --all-targets`
- [x] `cargo test -p tiygate-desktop --lib`
- [x] `cargo clippy -p tiygate-desktop --all-targets -- -D warnings`
- [x] `npm run lint` in `webui`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/master...HEAD`
- [x] `scripts/verify-deps.sh`
- [ ] Verify first-run passwordless setup with a packaged build on Windows 11.
- [ ] Verify repeated launches focus the existing Windows desktop window without starting another sidecar.

Close #35

🤖 Generated with [Codex](https://github.com/codex)
