### PR TITLE
fix(admin): 🐛 Preserve custom provider models endpoint

### DIFF
--- a/crates/admin/src/handlers.rs
+++ b/crates/admin/src/handlers.rs
@@ -2118,7 +2118,7 @@ fn normalized_models_endpoint(
         }
     } else if vendor == "openai"
         && matches!(auth_mode, AuthMode::ApiKey)
-        && (configured.is_empty() || configured == codex_models)
+        && configured == codex_models
     {
         return platform_models;
     }
@@ -3862,6 +3862,31 @@ mod tests {
         assert_eq!(
             normalized_models_endpoint("openai", AuthMode::OAuth, "", OPENAI_CODEX_BASE_URL),
             format!("{OPENAI_CODEX_BASE_URL}/models")
+        );
+    }
+
+    #[test]
+    fn openai_api_key_custom_base_derives_models_endpoint() {
+        assert_eq!(
+            normalized_models_endpoint("openai", AuthMode::ApiKey, "", "https://your-proxy.com/v1",),
+            "https://your-proxy.com/v1/models"
+        );
+        assert_eq!(
+            normalized_models_endpoint("openai", AuthMode::ApiKey, "", OPENAI_PLATFORM_BASE_URL),
+            format!("{OPENAI_PLATFORM_BASE_URL}/models")
+        );
+    }
+
+    #[test]
+    fn non_openai_api_key_custom_base_derives_models_endpoint() {
+        assert_eq!(
+            normalized_models_endpoint(
+                "anthropic",
+                AuthMode::ApiKey,
+                "",
+                "https://proxy.example.test/v1",
+            ),
+            "https://proxy.example.test/v1/models"
         );
     }
 

--- a/crates/admin/tests/integration.rs
+++ b/crates/admin/tests/integration.rs
@@ -154,6 +154,44 @@ async fn acceptance_1_admin_crud_propagates_to_routing_table() {
 }
 
 #[tokio::test]
+async fn openai_api_key_custom_base_derives_models_endpoint_when_omitted() {
+    let (router, store, _pool) = boot_no_auth().await;
+    let resp = router
+        .clone()
+        .oneshot(json_request(
+            "POST",
+            "/admin/v1/providers",
+            json!({
+                "id": "custom-openai",
+                "name": "Custom OpenAI",
+                "vendor": "openai",
+                "api_base": "https://your-proxy.com/v1",
+                "api_key": "sk-custom",
+                "auth_mode": "api_key",
+            }),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let body = axum::body::to_bytes(resp.into_body(), 8192)
+        .await
+        .expect("body");
+    let view: serde_json::Value = serde_json::from_slice(&body).expect("provider JSON");
+    assert_eq!(
+        view["models_endpoint"],
+        json!("https://your-proxy.com/v1/models")
+    );
+
+    let provider = store
+        .get_provider("custom-openai")
+        .await
+        .expect("get provider")
+        .expect("provider exists");
+    assert_eq!(provider.models_endpoint, "https://your-proxy.com/v1/models");
+}
+
+#[tokio::test]
 async fn provider_delete_impact_counts_linked_routes_and_empty_routes() {
     let (router, _store, _pool) = boot_no_auth().await;
     create_test_provider(&router, "prov-a").await;

--- a/webui/src/pages/Providers.tsx
+++ b/webui/src/pages/Providers.tsx
@@ -1014,10 +1014,11 @@ export default function Providers() {
           form.models_endpoint === `${OPENAI_PLATFORM_BASE_URL}/models`
           ? `${OPENAI_CODEX_BASE_URL}/models`
           : form.models_endpoint
-        : !form.models_endpoint ||
-            form.models_endpoint === `${OPENAI_CODEX_BASE_URL}/models`
-          ? `${OPENAI_PLATFORM_BASE_URL}/models`
-          : form.models_endpoint
+        : !form.models_endpoint
+          ? `${apiBase.replace(/\/+$/, "")}/models`
+          : form.models_endpoint === `${OPENAI_CODEX_BASE_URL}/models`
+            ? `${OPENAI_PLATFORM_BASE_URL}/models`
+            : form.models_endpoint
       : form.models_endpoint;
     const body: ProviderInput = {
       name: form.name,


### PR DESCRIPTION
## Summary
- Fix OpenAI API Key providers so an omitted models endpoint is derived from the configured custom API base.
- Preserve the existing OpenAI and Codex default endpoint compatibility behavior.
- Add unit and Admin API integration coverage for custom and non-OpenAI provider bases.

## Test Plan
- [x] `cargo test -p tiygate-admin`
- [x] `npm run lint`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Closes #69

🤖 Generated with [Codex Cli](https://developers.openai.com/codex/cli/)