### PR TITLE
fix(deepseek): 🐛 Default non-legacy models to Responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ Thumbs.db
 # Tauri client
 /src-tauri/binaries/
 /src-tauri/gen/
+
+# pi coding agent tooling artifacts (local session state, fusion output, task logs)
+.pi/

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -72,6 +72,35 @@ fn unique_responses_call_id(
     candidate
 }
 
+/// Extract replayable reasoning text from both OpenAI and DeepSeek Responses
+/// items. OpenAI carries summaries in `summary[].text`; DeepSeek carries the
+/// chain of thought in `content[{type:"reasoning_text",text:...}]`.
+fn responses_reasoning_text(item: &Value) -> String {
+    let content_text = item["content"].as_array().map(|content| {
+        content
+            .iter()
+            .filter(|part| part["type"] == "reasoning_text")
+            .filter_map(|part| part["text"].as_str())
+            .collect::<Vec<_>>()
+            .join("")
+    });
+
+    content_text
+        .filter(|text| !text.is_empty())
+        .or_else(|| {
+            item["summary"].as_array().map(|summary| {
+                summary
+                    .iter()
+                    .filter_map(|part| part["text"].as_str())
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+        })
+        .filter(|text| !text.is_empty())
+        .or_else(|| item["text"].as_str().map(String::from))
+        .unwrap_or_default()
+}
+
 fn responses_function_call_output(
     tool_call_id: &str,
     content: &str,
@@ -506,25 +535,38 @@ impl EndpointCodec for ResponsesCodec {
                         prompt_cache_breakpoint: None,
                     }]
                 } else if let Some(content_arr) = item["content"].as_array() {
-                    let mut parts = Vec::new();
-                    for part in content_arr {
-                        match part["type"].as_str() {
-                            Some("input_text") | Some("output_text") => {
-                                parts.push(Content::Text {
-                                    text: part["text"].as_str().unwrap_or("").to_string(),
-                                    annotations: None,
-                                    prompt_cache_breakpoint: decode_prompt_cache_breakpoint(part),
-                                });
-                            }
-                            Some("input_image") | Some("input_file") => {
-                                if let Some(media) = decode_responses_media_part(part) {
-                                    parts.push(media);
+                    if item["type"] == "reasoning" {
+                        vec![Content::Reasoning {
+                            text: responses_reasoning_text(item),
+                            signature: None,
+                            id: item["id"].as_str().map(|s| s.to_string()),
+                            encrypted_content: item["encrypted_content"]
+                                .as_str()
+                                .map(|s| s.to_string()),
+                        }]
+                    } else {
+                        let mut parts = Vec::new();
+                        for part in content_arr {
+                            match part["type"].as_str() {
+                                Some("input_text") | Some("output_text") => {
+                                    parts.push(Content::Text {
+                                        text: part["text"].as_str().unwrap_or("").to_string(),
+                                        annotations: None,
+                                        prompt_cache_breakpoint: decode_prompt_cache_breakpoint(
+                                            part,
+                                        ),
+                                    });
                                 }
+                                Some("input_image") | Some("input_file") => {
+                                    if let Some(media) = decode_responses_media_part(part) {
+                                        parts.push(media);
+                                    }
+                                }
+                                _ => {}
                             }
-                            _ => {}
                         }
+                        parts
                     }
-                    parts
                 } else if item["type"] == "program" {
                     vec![Content::Program {
                         id: item["id"].as_str().unwrap_or("").to_string(),
@@ -618,19 +660,7 @@ impl EndpointCodec for ResponsesCodec {
                     }]
                 } else if item["type"] == "reasoning" {
                     // Reasoning input item (replayed assistant chain-of-thought).
-                    // Pull the text out of the `summary` array (or a plain
-                    // `text` field) so the thinking survives a round-trip.
-                    let text = item["summary"]
-                        .as_array()
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|s| s["text"].as_str())
-                                .collect::<Vec<_>>()
-                                .join("")
-                        })
-                        .filter(|s| !s.is_empty())
-                        .or_else(|| item["text"].as_str().map(String::from))
-                        .unwrap_or_default();
+                    let text = responses_reasoning_text(item);
                     vec![Content::Reasoning {
                         text,
                         signature: None,
@@ -1937,20 +1967,9 @@ impl EndpointCodec for ResponsesCodec {
                         });
                     }
                     Some("reasoning") => {
-                        // Join the summary parts into a single reasoning block
-                        // so the Responses `id` maps to exactly one IR
-                        // Reasoning content (and re-encodes to exactly one
-                        // reasoning item, avoiding duplicate-id orphans).
-                        let text = item["summary"]
-                            .as_array()
-                            .map(|summary| {
-                                summary
-                                    .iter()
-                                    .filter_map(|s| s["text"].as_str())
-                                    .collect::<Vec<_>>()
-                                    .join("")
-                            })
-                            .unwrap_or_default();
+                        // Keep one IR reasoning block per Responses item. This
+                        // accepts OpenAI `summary` and DeepSeek `reasoning_text`.
+                        let text = responses_reasoning_text(item);
                         let id = item["id"].as_str().map(|s| s.to_string());
                         let encrypted_content =
                             item["encrypted_content"].as_str().map(|s| s.to_string());
@@ -3984,6 +4003,61 @@ mod tests {
             has_reasoning,
             "reasoning input item should decode to Reasoning"
         );
+    }
+
+    #[test]
+    fn test_decode_deepseek_reasoning_text_input_item() {
+        let codec = ResponsesCodec::new();
+        let env = make_raw_env();
+        let body = json!({
+            "model": "deepseek-v4-pro",
+            "input": [
+                {"role": "user", "content": "hi"},
+                {
+                    "type": "reasoning",
+                    "id": "rs_deepseek",
+                    "content": [
+                        {"type": "reasoning_text", "text": "first "},
+                        {"type": "reasoning_text", "text": "then second"}
+                    ],
+                    "summary": []
+                }
+            ]
+        });
+
+        let ir = codec.decode_request(body, &env).unwrap();
+        assert!(ir.messages.iter().any(|message| {
+            message.content.iter().any(|content| {
+                matches!(
+                    content,
+                    Content::Reasoning { text, id, .. }
+                        if text == "first then second" && id.as_deref() == Some("rs_deepseek")
+                )
+            })
+        }));
+    }
+
+    #[test]
+    fn test_decode_deepseek_reasoning_text_response_item() {
+        let codec = ResponsesCodec::new();
+        let body = json!({
+            "id": "resp_deepseek",
+            "object": "response",
+            "status": "completed",
+            "output": [{
+                "type": "reasoning",
+                "id": "rs_deepseek",
+                "content": [{"type": "reasoning_text", "text": "native reasoning"}],
+                "summary": []
+            }]
+        });
+
+        let ir = codec.decode_response(body).unwrap();
+        assert!(matches!(
+            &ir.content[0],
+            Content::Reasoning { text, id, .. }
+                if text == "native reasoning" && id.as_deref() == Some("rs_deepseek")
+        ));
     }
 
     #[test]

--- a/crates/providers/src/deepseek.rs
+++ b/crates/providers/src/deepseek.rs
@@ -53,10 +53,10 @@ impl Provider for DeepSeekProvider {
     }
 
     fn egress_protocol_for_model(&self, model_id: &str) -> ProtocolEndpoint {
-        if supports_responses_api(model_id) {
-            deepseek_responses_endpoint()
-        } else {
+        if uses_chat_completions(model_id) {
             ProtocolSuite::OpenAiCompatible.default_endpoint()
+        } else {
+            deepseek_responses_endpoint()
         }
     }
 
@@ -78,10 +78,10 @@ fn normalized_model_id(model_id: &str) -> String {
         .to_ascii_lowercase()
 }
 
-fn supports_responses_api(model_id: &str) -> bool {
+fn uses_chat_completions(model_id: &str) -> bool {
     matches!(
         normalized_model_id(model_id).as_str(),
-        "deepseek-v4-flash" | "deepseek-v4-pro" | "deepseek-v4-flash-vision-exp"
+        "deepseek-chat" | "deepseek-reasoner"
     )
 }
 
@@ -127,13 +127,15 @@ mod tests {
     }
 
     #[test]
-    fn v4_models_use_responses_and_legacy_models_keep_chat() {
+    fn only_legacy_chat_models_use_chat_completions() {
         let provider = DeepSeekProvider::new();
 
         for model in [
             "deepseek-v4-flash",
             "deepseek/deepseek-v4-pro:official",
             "deepseek-v4-flash-vision-exp",
+            "deepseek-v5-preview",
+            "unknown-model",
         ] {
             assert_eq!(
                 provider.egress_protocol_for_model(model).suite,
@@ -146,7 +148,12 @@ mod tests {
             );
         }
 
-        for model in ["deepseek-chat", "deepseek-reasoner", "unknown-model"] {
+        for model in [
+            "deepseek-chat",
+            "deepseek-reasoner",
+            "deepseek/deepseek-chat:official",
+            "deepseek/deepseek-reasoner:official",
+        ] {
             assert_eq!(
                 provider.egress_protocol_for_model(model).suite,
                 ProtocolSuite::OpenAiCompatible,

--- a/crates/providers/src/deepseek.rs
+++ b/crates/providers/src/deepseek.rs
@@ -21,14 +21,17 @@ impl DeepSeekProvider {
         Self {
             metadata: ProviderMetadata {
                 display_name: "DeepSeek".to_string(),
-                base_url: "https://api.deepseek.com/v1".to_string(),
+                base_url: "https://api.deepseek.com".to_string(),
                 auth_mode: AuthMode::Bearer,
                 channels: vec!["default".to_string()],
-                protocols: vec![ProtocolEndpoint::new(
-                    ProtocolSuite::OpenAiCompatible,
-                    "chat-completions",
-                    "v1",
-                )],
+                protocols: vec![
+                    deepseek_responses_endpoint(),
+                    ProtocolEndpoint::new(
+                        ProtocolSuite::OpenAiCompatible,
+                        "chat-completions",
+                        "v1",
+                    ),
+                ],
                 defaults: serde_json::json!({}),
             },
         }
@@ -49,9 +52,126 @@ impl Provider for DeepSeekProvider {
         Arc::new(BearerAuthApplier)
     }
 
-    fn egress_protocol_for_model(&self, _model_id: &str) -> ProtocolEndpoint {
-        ProtocolSuite::OpenAiCompatible.default_endpoint()
+    fn egress_protocol_for_model(&self, model_id: &str) -> ProtocolEndpoint {
+        if supports_responses_api(model_id) {
+            deepseek_responses_endpoint()
+        } else {
+            ProtocolSuite::OpenAiCompatible.default_endpoint()
+        }
+    }
+
+    fn egress_api_base(&self, raw_base: &str, endpoint: &ProtocolEndpoint) -> String {
+        deepseek_api_base(raw_base, endpoint.suite)
+    }
+}
+
+fn deepseek_responses_endpoint() -> ProtocolEndpoint {
+    ProtocolEndpoint::new(ProtocolSuite::OpenAiResponses, "deepseek-responses", "v1")
+}
+
+fn normalized_model_id(model_id: &str) -> String {
+    let without_provider = model_id.split(':').next().unwrap_or(model_id);
+    without_provider
+        .rsplit('/')
+        .next()
+        .unwrap_or(without_provider)
+        .to_ascii_lowercase()
+}
+
+fn supports_responses_api(model_id: &str) -> bool {
+    matches!(
+        normalized_model_id(model_id).as_str(),
+        "deepseek-v4-flash" | "deepseek-v4-pro" | "deepseek-v4-flash-vision-exp"
+    )
+}
+
+fn deepseek_api_base(raw_base: &str, suite: ProtocolSuite) -> String {
+    let base = raw_base.trim_end_matches('/');
+    let base = base
+        .strip_suffix("/v1")
+        .unwrap_or(base)
+        .trim_end_matches('/');
+
+    match suite {
+        ProtocolSuite::OpenAiResponses => base.to_string(),
+        ProtocolSuite::OpenAiCompatible => format!("{base}/v1"),
+        _ => raw_base.trim_end_matches('/').to_string(),
     }
 }
 
 inventory::submit! { tiygate_core::provider::ProviderRegistration { make: || Box::new(DeepSeekProvider::new()) } }
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_responses_and_chat_completions() {
+        let provider = DeepSeekProvider::new();
+        let suites: Vec<_> = provider
+            .supported_protocols()
+            .iter()
+            .map(|protocol| protocol.suite)
+            .collect();
+
+        assert_eq!(provider.metadata().base_url, "https://api.deepseek.com");
+        assert_eq!(provider.supported_protocols()[0].name, "deepseek-responses");
+        assert_eq!(
+            suites,
+            vec![
+                ProtocolSuite::OpenAiResponses,
+                ProtocolSuite::OpenAiCompatible
+            ]
+        );
+    }
+
+    #[test]
+    fn v4_models_use_responses_and_legacy_models_keep_chat() {
+        let provider = DeepSeekProvider::new();
+
+        for model in [
+            "deepseek-v4-flash",
+            "deepseek/deepseek-v4-pro:official",
+            "deepseek-v4-flash-vision-exp",
+        ] {
+            assert_eq!(
+                provider.egress_protocol_for_model(model).suite,
+                ProtocolSuite::OpenAiResponses,
+                "{model} should use Responses"
+            );
+            assert_eq!(
+                provider.egress_protocol_for_model(model).name,
+                "deepseek-responses"
+            );
+        }
+
+        for model in ["deepseek-chat", "deepseek-reasoner", "unknown-model"] {
+            assert_eq!(
+                provider.egress_protocol_for_model(model).suite,
+                ProtocolSuite::OpenAiCompatible,
+                "{model} should keep Chat Completions"
+            );
+        }
+    }
+
+    #[test]
+    fn api_base_is_normalized_per_protocol() {
+        let provider = DeepSeekProvider::new();
+        let responses = ProtocolSuite::OpenAiResponses.default_endpoint();
+        let chat = ProtocolSuite::OpenAiCompatible.default_endpoint();
+
+        assert_eq!(
+            provider.egress_api_base("https://api.deepseek.com/v1/", &responses),
+            "https://api.deepseek.com"
+        );
+        assert_eq!(
+            provider.egress_api_base("https://api.deepseek.com", &chat),
+            "https://api.deepseek.com/v1"
+        );
+        assert_eq!(
+            provider.egress_api_base("https://proxy.example/v1", &chat),
+            "https://proxy.example/v1"
+        );
+    }
+}

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -27,7 +27,7 @@ use crate::openai_codex_oauth as codex_oauth;
 use super::headers::{
     extract_rate_limit_headers, extract_retry_after, forward_upstream_resp_headers,
     forwarded_resp_headers_for_capture, header_map_to_vec, maybe_inject_prompt_cache_key,
-    merge_client_headers, normalize_openai_reasoning_for_target, override_model_in_body,
+    merge_client_headers, override_model_in_body, prepare_provider_request_body,
     reqwest_headers_to_vec, spawn_capture,
 };
 use super::response_model::ResponseModelOverride;
@@ -532,21 +532,20 @@ pub(super) async fn execute_upstream(
         encode_cross_protocol(codec, &egress_protocol, ir_request)?
     };
 
-    // Inject `prompt_cache_key` for OpenAI-family egress targets so that
-    // requests from the same caller are routed to the same inference
-    // machine, improving prompt-prefix cache hit rates.
-    let mut body_mutated =
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
-
     // Replace the (possibly virtual) model name with the routing
     // target's real upstream model id before sending and before we
     // snapshot the egress body for the request-log detail view.
-    body_mutated |= override_model_in_body(&mut upstream_body, &target.model_id);
-    body_mutated |= normalize_openai_reasoning_for_target(
+    let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
+    body_mutated |= prepare_provider_request_body(
         &mut upstream_body,
+        target,
         &egress_protocol.suite,
-        &target.model_id,
-    );
+        api_key_id,
+    )
+    .map_err(|message| {
+        AppError::new(StatusCode::BAD_REQUEST, message)
+            .with_class(tiygate_core::ErrorClass::LossyOrCapability)
+    })?;
     let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
         prepare_codex_egress_body(
             target,
@@ -1132,13 +1131,16 @@ pub(super) async fn execute_messages_upstream(
     // Replace the (possibly virtual) model name with the routing
     // target's real upstream model id.
     let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
-    body_mutated |=
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
-    body_mutated |= normalize_openai_reasoning_for_target(
+    body_mutated |= prepare_provider_request_body(
         &mut upstream_body,
+        target,
         &egress_protocol.suite,
-        &target.model_id,
-    );
+        api_key_id,
+    )
+    .map_err(|message| {
+        AppError::new(StatusCode::BAD_REQUEST, message)
+            .with_class(tiygate_core::ErrorClass::LossyOrCapability)
+    })?;
     let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
         prepare_codex_egress_body(
             target,
@@ -1970,13 +1972,16 @@ pub(super) async fn execute_responses_upstream(
     };
 
     let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
-    body_mutated |=
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
-    body_mutated |= normalize_openai_reasoning_for_target(
+    body_mutated |= prepare_provider_request_body(
         &mut upstream_body,
+        target,
         &egress_protocol.suite,
-        &target.model_id,
-    );
+        api_key_id,
+    )
+    .map_err(|message| {
+        AppError::new(StatusCode::BAD_REQUEST, message)
+            .with_class(tiygate_core::ErrorClass::LossyOrCapability)
+    })?;
     let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
         prepare_codex_egress_body(
             target,
@@ -2802,13 +2807,16 @@ pub(super) async fn execute_gemini_upstream(
     };
 
     let mut body_mutated = override_model_in_body(&mut upstream_body, &target.model_id);
-    body_mutated |=
-        maybe_inject_prompt_cache_key(&mut upstream_body, &egress_protocol.suite, api_key_id);
-    body_mutated |= normalize_openai_reasoning_for_target(
+    body_mutated |= prepare_provider_request_body(
         &mut upstream_body,
+        target,
         &egress_protocol.suite,
-        &target.model_id,
-    );
+        api_key_id,
+    )
+    .map_err(|message| {
+        AppError::new(StatusCode::BAD_REQUEST, message)
+            .with_class(tiygate_core::ErrorClass::LossyOrCapability)
+    })?;
     let (openai_codex_profile, codex_websocket, codex_body_changed, codex_session_key) =
         prepare_codex_egress_body(
             target,

--- a/crates/server/src/ingress/fallback.rs
+++ b/crates/server/src/ingress/fallback.rs
@@ -14,6 +14,7 @@ use tiygate_core::{
     RetryPolicy,
 };
 
+use super::observability::protocol_log_label;
 use super::{build_strategy, AppError, AppState};
 
 async fn emit_hop_decision(
@@ -200,10 +201,7 @@ where
                     target: health_key.clone(),
                     provider: target.provider_id.clone(),
                     model: target.model_id.clone(),
-                    egress_protocol: format!(
-                        "{:?}/{}",
-                        target.api_protocol.suite, target.api_protocol.name
-                    ),
+                    egress_protocol: protocol_log_label(&target.api_protocol),
                     hop: current_hop,
                 },
             })

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -365,7 +365,10 @@ fn strip_ignored_deepseek_control(
     field: &str,
 ) -> bool {
     let mut mutated = false;
-    if let Some(object) = body.pointer_mut(container).and_then(|value| value.as_object_mut()) {
+    if let Some(object) = body
+        .pointer_mut(container)
+        .and_then(|value| value.as_object_mut())
+    {
         mutated |= object.remove(field).is_some();
     }
     let emptied = body

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -183,18 +183,27 @@ pub(super) fn maybe_inject_prompt_cache_key(
     true
 }
 
-/// Return whether the normalized upstream model id belongs to GPT-5.6.
-fn supports_openai_reasoning_max(model_id: &str) -> bool {
+fn normalized_model_id(model_id: &str) -> String {
     let without_provider = model_id.split(':').next().unwrap_or(model_id);
-    let model = without_provider
+    without_provider
         .rsplit('/')
         .next()
         .unwrap_or(without_provider)
-        .to_ascii_lowercase();
-    model == "gpt-5.6" || model.starts_with("gpt-5.6-")
+        .to_ascii_lowercase()
 }
 
-/// Downgrade GPT-5.6-only `max` reasoning for older OpenAI-family targets.
+/// Return whether the target accepts the `max` reasoning effort verbatim.
+fn supports_reasoning_max(model_id: &str) -> bool {
+    let model = normalized_model_id(model_id);
+    model == "gpt-5.6"
+        || model.starts_with("gpt-5.6-")
+        || matches!(
+            model.as_str(),
+            "deepseek-v4-flash" | "deepseek-v4-pro" | "deepseek-v4-flash-vision-exp"
+        )
+}
+
+/// Downgrade `max` reasoning for OpenAI-family targets that do not declare it.
 /// The codec sees a virtual model; this helper runs after routing and therefore
 /// uses the real `target.model_id`.
 pub(super) fn normalize_openai_reasoning_for_target(
@@ -202,7 +211,7 @@ pub(super) fn normalize_openai_reasoning_for_target(
     egress_suite: &tiygate_core::ProtocolSuite,
     target_model_id: &str,
 ) -> bool {
-    if supports_openai_reasoning_max(target_model_id) {
+    if supports_reasoning_max(target_model_id) {
         return false;
     }
     let effort = match egress_suite {
@@ -219,6 +228,294 @@ pub(super) fn normalize_openai_reasoning_for_target(
         }
     }
     false
+}
+
+fn is_meaningful(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::Bool(value) => *value,
+        serde_json::Value::String(value) => !value.is_empty(),
+        serde_json::Value::Array(value) => !value.is_empty(),
+        serde_json::Value::Object(value) => !value.is_empty(),
+        serde_json::Value::Number(_) => true,
+    }
+}
+
+fn is_official_deepseek_responses_target(
+    target: &tiygate_core::RoutingTarget,
+    egress_suite: &tiygate_core::ProtocolSuite,
+) -> bool {
+    if *egress_suite != tiygate_core::ProtocolSuite::OpenAiResponses {
+        return false;
+    }
+    if target.provider_id == "deepseek" || target.api_protocol.name == "deepseek-responses" {
+        return true;
+    }
+    url::Url::parse(target.effective_api_base())
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string))
+        .is_some_and(|host| host.eq_ignore_ascii_case("api.deepseek.com"))
+}
+
+fn deepseek_capability_error(detail: impl Into<String>) -> String {
+    format!("DeepSeek Responses capability rejected: {}", detail.into())
+}
+
+fn validate_deepseek_message_content(item: &serde_json::Value) -> Result<(), String> {
+    let Some(parts) = item.get("content").and_then(|value| value.as_array()) else {
+        return Ok(());
+    };
+    for part in parts {
+        match part.get("type").and_then(|value| value.as_str()) {
+            Some("input_text") | Some("output_text") | Some("input_image") => {}
+            Some("input_file") => {
+                return Err(deepseek_capability_error(
+                    "input_file content is not supported",
+                ));
+            }
+            Some(other) => {
+                return Err(deepseek_capability_error(format!(
+                    "message content type {other} is not supported"
+                )));
+            }
+            None => {}
+        }
+    }
+    Ok(())
+}
+
+fn validate_deepseek_tool_output(item: &serde_json::Value) -> Result<(), String> {
+    let Some(parts) = item.get("output").and_then(|value| value.as_array()) else {
+        return Ok(());
+    };
+    for part in parts {
+        match part.get("type").and_then(|value| value.as_str()) {
+            Some("input_text") | Some("input_image") => {}
+            Some(other) => {
+                return Err(deepseek_capability_error(format!(
+                    "tool output content type {other} is not supported"
+                )));
+            }
+            None => {}
+        }
+    }
+    Ok(())
+}
+
+fn prepare_deepseek_reasoning_item(item: &mut serde_json::Value) -> Result<bool, String> {
+    if item.get("encrypted_content").is_some_and(is_meaningful) {
+        return Err(deepseek_capability_error(
+            "reasoning.encrypted_content is not supported",
+        ));
+    }
+
+    if let Some(parts) = item.get("content").and_then(|value| value.as_array()) {
+        for part in parts {
+            if part.get("type").and_then(|value| value.as_str()) != Some("reasoning_text") {
+                return Err(deepseek_capability_error(
+                    "reasoning content only supports reasoning_text parts",
+                ));
+            }
+        }
+    }
+
+    let summary_text = item
+        .get("summary")
+        .and_then(|value| value.as_array())
+        .map(|summary| {
+            summary
+                .iter()
+                .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .filter(|text| !text.is_empty())
+        .or_else(|| {
+            item.get("text")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        });
+    let has_content = item
+        .get("content")
+        .and_then(|value| value.as_array())
+        .is_some_and(|parts| !parts.is_empty());
+    if !has_content {
+        let text = summary_text.ok_or_else(|| {
+            deepseek_capability_error("reasoning input must contain reasoning_text content")
+        })?;
+        item["content"] = serde_json::json!([{"type": "reasoning_text", "text": text}]);
+    }
+
+    let object = item
+        .as_object_mut()
+        .ok_or_else(|| deepseek_capability_error("reasoning input item must be a JSON object"))?;
+    let removed_summary = object.remove("summary").is_some();
+    let removed_text = object.remove("text").is_some();
+    let removed_encrypted = object.remove("encrypted_content").is_some();
+    Ok(!has_content || removed_summary || removed_text || removed_encrypted)
+}
+
+/// Apply the official DeepSeek Responses compatibility profile. The upstream
+/// silently ignores unsupported OpenAI fields, so TiyGate rejects semantic
+/// loss and converts replayable OpenAI reasoning summaries to DeepSeek's
+/// `reasoning_text` input form before sending the request.
+fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bool, String> {
+    for field in [
+        "previous_response_id",
+        "conversation",
+        "background",
+        "max_tool_calls",
+        "prompt",
+        "service_tier",
+        "safety_identifier",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "prompt_cache_options",
+        "context_management",
+        "stream_options",
+        "client_metadata",
+        "multi_agent",
+        "stop",
+        "presence_penalty",
+        "frequency_penalty",
+        "seed",
+        "n",
+        "logprobs",
+    ] {
+        if body.get(field).is_some_and(is_meaningful) {
+            return Err(deepseek_capability_error(format!(
+                "{field} is not supported"
+            )));
+        }
+    }
+    if body.get("store").and_then(|value| value.as_bool()) == Some(true) {
+        return Err(deepseek_capability_error("store=true is not supported"));
+    }
+    if body.get("metadata").is_some_and(is_meaningful)
+        || body.get("include").is_some_and(is_meaningful)
+    {
+        return Err(deepseek_capability_error(
+            "metadata and include are not supported",
+        ));
+    }
+    if body
+        .get("parallel_tool_calls")
+        .and_then(|value| value.as_bool())
+        == Some(false)
+    {
+        return Err(deepseek_capability_error(
+            "parallel_tool_calls=false is not supported; DeepSeek always enables it",
+        ));
+    }
+    if body
+        .get("truncation")
+        .and_then(|value| value.as_str())
+        .is_some_and(|value| value != "disabled")
+    {
+        return Err(deepseek_capability_error(
+            "automatic truncation is not supported",
+        ));
+    }
+    if body.pointer("/text/verbosity").is_some_and(is_meaningful) {
+        return Err(deepseek_capability_error(
+            "text.verbosity is accepted but ignored by DeepSeek",
+        ));
+    }
+    if body
+        .pointer("/reasoning/summary")
+        .and_then(|value| value.as_str())
+        .is_some_and(|value| value != "none")
+    {
+        return Err(deepseek_capability_error(
+            "reasoning.summary is accepted but no summary is generated",
+        ));
+    }
+
+    if let Some(tools) = body.get("tools").and_then(|value| value.as_array()) {
+        for tool in tools {
+            match tool.get("type").and_then(|value| value.as_str()) {
+                Some("function") => {}
+                Some("web_search") | Some("web_search_2025_08_26") => {
+                    if tool.get("search_context_size").is_some_and(is_meaningful)
+                        || tool.get("user_location").is_some_and(is_meaningful)
+                    {
+                        return Err(deepseek_capability_error(
+                            "web_search search_context_size and user_location are ignored",
+                        ));
+                    }
+                }
+                Some("custom")
+                    if tool.get("name").and_then(|value| value.as_str()) == Some("apply_patch") => {
+                }
+                Some("custom") => {
+                    return Err(deepseek_capability_error(
+                        "only the apply_patch custom tool is supported",
+                    ));
+                }
+                Some(other) => {
+                    return Err(deepseek_capability_error(format!(
+                        "tool type {other} is not supported"
+                    )));
+                }
+                None => {
+                    return Err(deepseek_capability_error("tool type is required"));
+                }
+            }
+        }
+    }
+
+    let mut mutated = false;
+    if let Some(items) = body.get_mut("input").and_then(|value| value.as_array_mut()) {
+        for item in items {
+            let item_type = item.get("type").and_then(|value| value.as_str());
+            match item_type {
+                Some("reasoning") => mutated |= prepare_deepseek_reasoning_item(item)?,
+                Some("message") | None if item.get("role").is_some() => {
+                    validate_deepseek_message_content(item)?;
+                }
+                Some("function_call") | Some("web_search_call") => {}
+                Some("function_call_output") | Some("custom_tool_call_output") => {
+                    validate_deepseek_tool_output(item)?;
+                }
+                Some("custom_tool_call") => {
+                    if item.get("name").and_then(|value| value.as_str()) != Some("apply_patch") {
+                        return Err(deepseek_capability_error(
+                            "only apply_patch custom_tool_call items are supported",
+                        ));
+                    }
+                }
+                Some(other) => {
+                    return Err(deepseek_capability_error(format!(
+                        "input item type {other} is not supported"
+                    )));
+                }
+                None => {
+                    return Err(deepseek_capability_error(
+                        "input item must have a supported type or role",
+                    ));
+                }
+            }
+        }
+    }
+    Ok(mutated)
+}
+
+pub(super) fn prepare_provider_request_body(
+    body: &mut serde_json::Value,
+    target: &tiygate_core::RoutingTarget,
+    egress_suite: &tiygate_core::ProtocolSuite,
+    api_key_id: &str,
+) -> Result<bool, String> {
+    let deepseek_responses = is_official_deepseek_responses_target(target, egress_suite);
+    let mut mutated = false;
+    if !deepseek_responses {
+        mutated |= maybe_inject_prompt_cache_key(body, egress_suite, api_key_id);
+    }
+    mutated |= normalize_openai_reasoning_for_target(body, egress_suite, &target.model_id);
+    if deepseek_responses {
+        mutated |= prepare_deepseek_responses_request(body)?;
+    }
+    Ok(mutated)
 }
 
 /// Extract Retry-After value from response headers.
@@ -278,6 +575,144 @@ mod tests {
             "gpt-5.4"
         ));
         assert_eq!(chat["reasoning_effort"], "xhigh");
+
+        let mut deepseek = serde_json::json!({"reasoning": {"effort": "max"}});
+        assert!(!normalize_openai_reasoning_for_target(
+            &mut deepseek,
+            &tiygate_core::ProtocolSuite::OpenAiResponses,
+            "deepseek/deepseek-v4-pro:official"
+        ));
+        assert_eq!(deepseek["reasoning"]["effort"], "max");
+    }
+
+    fn deepseek_target() -> tiygate_core::RoutingTarget {
+        tiygate_core::RoutingTarget {
+            provider_id: "deepseek".to_string(),
+            model_id: "deepseek-v4-pro".to_string(),
+            api_base: "https://api.deepseek.com".to_string(),
+            api_key: "sk-test".to_string(),
+            api_protocol: tiygate_core::ProtocolSuite::OpenAiResponses.default_endpoint(),
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            weight: 1.0,
+            oauth: None,
+        }
+    }
+
+    #[test]
+    fn deepseek_responses_converts_reasoning_summary_and_preserves_max() {
+        let target = deepseek_target();
+        let mut body = serde_json::json!({
+            "model": "deepseek-v4-pro",
+            "reasoning": {"effort": "max", "summary": "none"},
+            "input": [
+                {"role": "user", "content": "weather?"},
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "call weather"}]
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "weather",
+                    "arguments": "{}"
+                }
+            ],
+            "tools": [{
+                "type": "function",
+                "name": "weather",
+                "parameters": {"type": "object"}
+            }]
+        });
+
+        let prepared = prepare_provider_request_body(
+            &mut body,
+            &target,
+            &tiygate_core::ProtocolSuite::OpenAiResponses,
+            "key-1",
+        );
+        assert!(
+            matches!(prepared, Ok(true)),
+            "unexpected result: {prepared:?}"
+        );
+        assert_eq!(body["reasoning"]["effort"], "max");
+        assert_eq!(body["input"][1]["content"][0]["type"], "reasoning_text");
+        assert_eq!(body["input"][1]["content"][0]["text"], "call weather");
+        assert!(body["input"][1].get("summary").is_none());
+        assert!(body.get("prompt_cache_key").is_none());
+    }
+
+    #[test]
+    fn deepseek_profile_survives_database_id_and_proxy_override() {
+        let mut target = deepseek_target();
+        target.provider_id = "provider-row-id".to_string();
+        target.api_base = "https://proxy.example/deepseek".to_string();
+        target.api_protocol = tiygate_core::ProtocolEndpoint::new(
+            tiygate_core::ProtocolSuite::OpenAiResponses,
+            "deepseek-responses",
+            "v1",
+        );
+
+        assert!(is_official_deepseek_responses_target(
+            &target,
+            &tiygate_core::ProtocolSuite::OpenAiResponses
+        ));
+        let mut body = serde_json::json!({
+            "input": "hi",
+            "tools": [{"type": "mcp", "server_label": "internal"}]
+        });
+        let result = prepare_provider_request_body(
+            &mut body,
+            &target,
+            &tiygate_core::ProtocolSuite::OpenAiResponses,
+            "anonymous",
+        );
+        assert!(
+            matches!(&result, Err(error) if error.contains("mcp")),
+            "unexpected result: {result:?}"
+        );
+    }
+
+    #[test]
+    fn deepseek_responses_rejects_silently_ignored_capabilities() {
+        let target = deepseek_target();
+        for (field, mut body) in [
+            (
+                "previous_response_id",
+                serde_json::json!({"input": "hi", "previous_response_id": "resp_1"}),
+            ),
+            (
+                "file_search",
+                serde_json::json!({"input": "hi", "tools": [{"type": "file_search"}]}),
+            ),
+            (
+                "verbosity",
+                serde_json::json!({"input": "hi", "text": {"verbosity": "high"}}),
+            ),
+            (
+                "encrypted_content",
+                serde_json::json!({
+                    "input": [{
+                        "type": "reasoning",
+                        "encrypted_content": "opaque",
+                        "summary": []
+                    }]
+                }),
+            ),
+        ] {
+            let result = prepare_provider_request_body(
+                &mut body,
+                &target,
+                &tiygate_core::ProtocolSuite::OpenAiResponses,
+                "anonymous",
+            );
+            assert!(
+                matches!(&result, Err(error) if error.contains(field)),
+                "unexpected result: {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -360,6 +360,20 @@ fn prepare_deepseek_reasoning_item(item: &mut serde_json::Value) -> Result<bool,
 /// loss and converts replayable OpenAI reasoning summaries to DeepSeek's
 /// `reasoning_text` input form before sending the request.
 fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bool, String> {
+    // DeepSeek manages context caching automatically. Codex clients commonly
+    // send OpenAI cache-affinity hints, so strip those non-semantic controls
+    // instead of rejecting an otherwise compatible request.
+    let mut mutated = false;
+    if let Some(object) = body.as_object_mut() {
+        for field in [
+            "prompt_cache_key",
+            "prompt_cache_retention",
+            "prompt_cache_options",
+        ] {
+            mutated |= object.remove(field).is_some();
+        }
+    }
+
     for field in [
         "previous_response_id",
         "conversation",
@@ -368,9 +382,6 @@ fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bo
         "prompt",
         "service_tier",
         "safety_identifier",
-        "prompt_cache_key",
-        "prompt_cache_retention",
-        "prompt_cache_options",
         "context_management",
         "stream_options",
         "client_metadata",
@@ -464,7 +475,6 @@ fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bo
         }
     }
 
-    let mut mutated = false;
     if let Some(items) = body.get_mut("input").and_then(|value| value.as_array_mut()) {
         for item in items {
             let item_type = item.get("type").and_then(|value| value.as_str());
@@ -606,6 +616,9 @@ mod tests {
         let mut body = serde_json::json!({
             "model": "deepseek-v4-pro",
             "reasoning": {"effort": "max", "summary": "none"},
+            "prompt_cache_key": "codex-session",
+            "prompt_cache_retention": "24h",
+            "prompt_cache_options": {"mode": "explicit"},
             "input": [
                 {"role": "user", "content": "weather?"},
                 {
@@ -642,6 +655,8 @@ mod tests {
         assert_eq!(body["input"][1]["content"][0]["text"], "call weather");
         assert!(body["input"][1].get("summary").is_none());
         assert!(body.get("prompt_cache_key").is_none());
+        assert!(body.get("prompt_cache_retention").is_none());
+        assert!(body.get("prompt_cache_options").is_none());
     }
 
     #[test]

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -302,11 +302,39 @@ fn validate_deepseek_tool_output(item: &serde_json::Value) -> Result<(), String>
     Ok(())
 }
 
-fn prepare_deepseek_reasoning_item(item: &mut serde_json::Value) -> Result<bool, String> {
+/// How a DeepSeek reasoning input item should be handled after preparation.
+enum PreparedReasoningItem {
+    /// Keep the item; the bool reports whether its body was mutated.
+    Keep { changed: bool },
+    /// Drop the whole item — nothing DeepSeek can consume remains.
+    Drop,
+}
+
+fn prepare_deepseek_reasoning_item(
+    item: &mut serde_json::Value,
+) -> Result<PreparedReasoningItem, String> {
+    // DeepSeek cannot decrypt OpenAI-style encrypted reasoning. When a client
+    // echoes a reasoning item back that carries an encrypted blob, DeepSeek can
+    // never consume it. Treat it like the other "accepted-but-ignored" controls:
+    // strip the blob and keep any plaintext instead of rejecting the whole
+    // request. When the item is encrypted-only (no plaintext summary or
+    // reasoning_text), there is nothing DeepSeek can use, so drop the item.
     if item.get("encrypted_content").is_some_and(is_meaningful) {
-        return Err(deepseek_capability_error(
-            "reasoning.encrypted_content is not supported",
-        ));
+        let has_plaintext = item
+            .get("content")
+            .and_then(|value| value.as_array())
+            .is_some_and(|parts| !parts.is_empty())
+            || item
+                .get("summary")
+                .and_then(|value| value.as_array())
+                .is_some_and(|parts| !parts.is_empty())
+            || item
+                .get("text")
+                .and_then(|value| value.as_str())
+                .is_some_and(|text| !text.is_empty());
+        if !has_plaintext {
+            return Ok(PreparedReasoningItem::Drop);
+        }
     }
 
     if let Some(parts) = item.get("content").and_then(|value| value.as_array()) {
@@ -352,7 +380,9 @@ fn prepare_deepseek_reasoning_item(item: &mut serde_json::Value) -> Result<bool,
     let removed_summary = object.remove("summary").is_some();
     let removed_text = object.remove("text").is_some();
     let removed_encrypted = object.remove("encrypted_content").is_some();
-    Ok(!has_content || removed_summary || removed_text || removed_encrypted)
+    Ok(PreparedReasoningItem::Keep {
+        changed: !has_content || removed_summary || removed_text || removed_encrypted,
+    })
 }
 
 /// Remove a DeepSeek-accepted-but-ignored control field from a nested object.
@@ -495,10 +525,14 @@ fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bo
     }
 
     if let Some(items) = body.get_mut("input").and_then(|value| value.as_array_mut()) {
-        for item in items {
+        let mut drop_indices: Vec<usize> = Vec::new();
+        for (idx, item) in items.iter_mut().enumerate() {
             let item_type = item.get("type").and_then(|value| value.as_str());
             match item_type {
-                Some("reasoning") => mutated |= prepare_deepseek_reasoning_item(item)?,
+                Some("reasoning") => match prepare_deepseek_reasoning_item(item)? {
+                    PreparedReasoningItem::Keep { changed } => mutated |= changed,
+                    PreparedReasoningItem::Drop => drop_indices.push(idx),
+                },
                 Some("message") | None if item.get("role").is_some() => {
                     validate_deepseek_message_content(item)?;
                 }
@@ -524,6 +558,14 @@ fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bo
                     ));
                 }
             }
+        }
+        // Remove reasoning items DeepSeek can no longer consume (encrypted-only
+        // shells with no plaintext). Reverse order keeps indices valid.
+        if !drop_indices.is_empty() {
+            for idx in drop_indices.into_iter().rev() {
+                items.remove(idx);
+            }
+            mutated = true;
         }
     }
     Ok(mutated)
@@ -728,16 +770,6 @@ mod tests {
                 "file_search",
                 serde_json::json!({"input": "hi", "tools": [{"type": "file_search"}]}),
             ),
-            (
-                "encrypted_content",
-                serde_json::json!({
-                    "input": [{
-                        "type": "reasoning",
-                        "encrypted_content": "opaque",
-                        "summary": []
-                    }]
-                }),
-            ),
         ] {
             let result = prepare_provider_request_body(
                 &mut body,
@@ -750,6 +782,60 @@ mod tests {
                 "unexpected result: {result:?}"
             );
         }
+    }
+
+    #[test]
+    fn deepseek_responses_strips_or_drops_encrypted_reasoning() {
+        let target = deepseek_target();
+
+        // 1. Encrypted-only shell (no plaintext summary / content / text):
+        //    DeepSeek can consume nothing, so the whole reasoning item is
+        //    dropped rather than rejecting the entire request.
+        let mut body = serde_json::json!({
+            "input": [{
+                "type": "reasoning",
+                "encrypted_content": "opaque",
+                "summary": []
+            }]
+        });
+        let prepared = prepare_provider_request_body(
+            &mut body,
+            &target,
+            &tiygate_core::ProtocolSuite::OpenAiResponses,
+            "anonymous",
+        );
+        assert!(
+            matches!(prepared, Ok(true)),
+            "encrypted-only reasoning should be stripped, not rejected: {prepared:?}"
+        );
+        assert_eq!(body["input"].as_array().map(|arr| arr.len()), Some(0));
+
+        // 2. Encrypted blob alongside a plaintext summary: strip the blob and
+        //    keep the plaintext as DeepSeek `reasoning_text`.
+        let mut body = serde_json::json!({
+            "input": [
+                {"role": "user", "content": "weather?"},
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "opaque",
+                    "summary": [{"type": "summary_text", "text": "call weather"}]
+                }
+            ]
+        });
+        let prepared = prepare_provider_request_body(
+            &mut body,
+            &target,
+            &tiygate_core::ProtocolSuite::OpenAiResponses,
+            "anonymous",
+        );
+        assert!(
+            matches!(prepared, Ok(true)),
+            "encrypted reasoning with plaintext should be converted: {prepared:?}"
+        );
+        assert_eq!(body["input"][1]["content"][0]["type"], "reasoning_text");
+        assert_eq!(body["input"][1]["content"][0]["text"], "call weather");
+        assert!(body["input"][1].get("encrypted_content").is_none());
+        assert!(body["input"][1].get("summary").is_none());
     }
 
     #[test]

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -360,15 +360,20 @@ fn prepare_deepseek_reasoning_item(item: &mut serde_json::Value) -> Result<bool,
 /// loss and converts replayable OpenAI reasoning summaries to DeepSeek's
 /// `reasoning_text` input form before sending the request.
 fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bool, String> {
-    // DeepSeek manages context caching automatically. Codex clients commonly
-    // send OpenAI cache-affinity hints, so strip those non-semantic controls
-    // instead of rejecting an otherwise compatible request.
+    // DeepSeek manages context caching automatically and silently ignores
+    // non-semantic OpenAI controls. Codex clients commonly send cache-affinity
+    // hints (`prompt_cache_*`), client-side tags (`metadata`), and a response
+    // item selector (`include`). DeepSeek never parses these, and it returns
+    // reasoning/tool items automatically, so stripping them is lossless.
+    // Strip them instead of rejecting an otherwise compatible request.
     let mut mutated = false;
     if let Some(object) = body.as_object_mut() {
         for field in [
             "prompt_cache_key",
             "prompt_cache_retention",
             "prompt_cache_options",
+            "metadata",
+            "include",
         ] {
             mutated |= object.remove(field).is_some();
         }
@@ -401,13 +406,6 @@ fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bo
     }
     if body.get("store").and_then(|value| value.as_bool()) == Some(true) {
         return Err(deepseek_capability_error("store=true is not supported"));
-    }
-    if body.get("metadata").is_some_and(is_meaningful)
-        || body.get("include").is_some_and(is_meaningful)
-    {
-        return Err(deepseek_capability_error(
-            "metadata and include are not supported",
-        ));
     }
     if body
         .get("parallel_tool_calls")
@@ -619,6 +617,8 @@ mod tests {
             "prompt_cache_key": "codex-session",
             "prompt_cache_retention": "24h",
             "prompt_cache_options": {"mode": "explicit"},
+            "metadata": {"user_id": "codex-session-1"},
+            "include": ["reasoning.encrypted_content"],
             "input": [
                 {"role": "user", "content": "weather?"},
                 {
@@ -657,6 +657,8 @@ mod tests {
         assert!(body.get("prompt_cache_key").is_none());
         assert!(body.get("prompt_cache_retention").is_none());
         assert!(body.get("prompt_cache_options").is_none());
+        assert!(body.get("metadata").is_none());
+        assert!(body.get("include").is_none());
     }
 
     #[test]

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -355,6 +355,32 @@ fn prepare_deepseek_reasoning_item(item: &mut serde_json::Value) -> Result<bool,
     Ok(!has_content || removed_summary || removed_text || removed_encrypted)
 }
 
+/// Remove a DeepSeek-accepted-but-ignored control field from a nested object.
+/// Returns true if `body` was mutated. When the container object becomes
+/// empty after the removal, the container is dropped so we never forward an
+/// empty object that DeepSeek may treat differently from an absent one.
+fn strip_ignored_deepseek_control(
+    body: &mut serde_json::Value,
+    container: &str,
+    field: &str,
+) -> bool {
+    let mut mutated = false;
+    if let Some(object) = body.pointer_mut(container).and_then(|value| value.as_object_mut()) {
+        mutated |= object.remove(field).is_some();
+    }
+    let emptied = body
+        .pointer(container)
+        .and_then(|value| value.as_object())
+        .is_some_and(|object| object.is_empty());
+    if emptied {
+        let key = container.trim_start_matches('/');
+        if let Some(root) = body.as_object_mut() {
+            mutated |= root.remove(key).is_some();
+        }
+    }
+    mutated
+}
+
 /// Apply the official DeepSeek Responses compatibility profile. The upstream
 /// silently ignores unsupported OpenAI fields, so TiyGate rejects semantic
 /// loss and converts replayable OpenAI reasoning summaries to DeepSeek's
@@ -425,20 +451,12 @@ fn prepare_deepseek_responses_request(body: &mut serde_json::Value) -> Result<bo
             "automatic truncation is not supported",
         ));
     }
-    if body.pointer("/text/verbosity").is_some_and(is_meaningful) {
-        return Err(deepseek_capability_error(
-            "text.verbosity is accepted but ignored by DeepSeek",
-        ));
-    }
-    if body
-        .pointer("/reasoning/summary")
-        .and_then(|value| value.as_str())
-        .is_some_and(|value| value != "none")
-    {
-        return Err(deepseek_capability_error(
-            "reasoning.summary is accepted but no summary is generated",
-        ));
-    }
+    // DeepSeek accepts but ignores `text.verbosity` and `reasoning.summary`.
+    // Codex clients commonly set them, so strip these no-op controls instead of
+    // rejecting an otherwise compatible request. If the container becomes empty
+    // after stripping, drop it so we never forward an empty object.
+    mutated |= strip_ignored_deepseek_control(body, "/text", "verbosity");
+    mutated |= strip_ignored_deepseek_control(body, "/reasoning", "summary");
 
     if let Some(tools) = body.get("tools").and_then(|value| value.as_array()) {
         for tool in tools {
@@ -613,7 +631,8 @@ mod tests {
         let target = deepseek_target();
         let mut body = serde_json::json!({
             "model": "deepseek-v4-pro",
-            "reasoning": {"effort": "max", "summary": "none"},
+            "reasoning": {"effort": "max", "summary": "auto"},
+            "text": {"verbosity": "high"},
             "prompt_cache_key": "codex-session",
             "prompt_cache_retention": "24h",
             "prompt_cache_options": {"mode": "explicit"},
@@ -659,6 +678,8 @@ mod tests {
         assert!(body.get("prompt_cache_options").is_none());
         assert!(body.get("metadata").is_none());
         assert!(body.get("include").is_none());
+        assert!(body["reasoning"].get("summary").is_none());
+        assert!(body.get("text").is_none());
     }
 
     #[test]
@@ -703,10 +724,6 @@ mod tests {
             (
                 "file_search",
                 serde_json::json!({"input": "hi", "tools": [{"type": "file_search"}]}),
-            ),
-            (
-                "verbosity",
-                serde_json::json!({"input": "hi", "text": {"verbosity": "high"}}),
             ),
             (
                 "encrypted_content",

--- a/crates/server/src/ingress/observability.rs
+++ b/crates/server/src/ingress/observability.rs
@@ -943,6 +943,18 @@ pub(super) async fn embedding_cache_store(
     }
 }
 
+/// Serialize a protocol endpoint for operator-facing logs. Provider-specific
+/// Responses profiles share the public Responses wire protocol, so their
+/// internal endpoint names must not leak into log categorization.
+pub(super) fn protocol_log_label(protocol: &ProtocolEndpoint) -> String {
+    let name = if protocol.suite == tiygate_core::ProtocolSuite::OpenAiResponses {
+        protocol.suite.default_endpoint_id().0
+    } else {
+        protocol.name.as_str()
+    };
+    format!("{}/{}/{}", protocol.suite.label(), name, protocol.version)
+}
+
 /// Build a `RequestEvent` from the request hot-path data and push
 /// it to the telemetry bus. Phase-4 OltpSink picks it up; stdout
 /// sinks surface it as JSON.
@@ -978,13 +990,8 @@ pub(super) fn emit_request_event(
         trace_id: Some(trace.trace_id.clone()),
         span_id: Some(trace.parent_span_id.clone()),
         traceparent: Some(trace.to_traceparent()),
-        ingress_protocol: format!(
-            "{}/{}/{}",
-            ingress.suite.label(),
-            ingress.name,
-            ingress.version
-        ),
-        egress_protocol: egress.map(|e| format!("{}/{}/{}", e.suite.label(), e.name, e.version)),
+        ingress_protocol: protocol_log_label(ingress),
+        egress_protocol: egress.map(protocol_log_label),
         lossy,
         cache_hit: cache_hit.map(str::to_string),
         status,
@@ -1034,6 +1041,32 @@ pub(super) fn emit_request_event(
     tokio::spawn(async move {
         bus2.send(pe).await;
     });
+}
+
+#[cfg(test)]
+mod protocol_log_tests {
+    use super::protocol_log_label;
+    use tiygate_core::{ProtocolEndpoint, ProtocolSuite};
+
+    #[test]
+    fn responses_profiles_use_the_public_responses_label() {
+        let endpoint =
+            ProtocolEndpoint::new(ProtocolSuite::OpenAiResponses, "deepseek-responses", "v1");
+        assert_eq!(
+            protocol_log_label(&endpoint),
+            "openai-responses/responses/v1"
+        );
+    }
+
+    #[test]
+    fn non_responses_endpoint_names_are_preserved() {
+        let endpoint =
+            ProtocolEndpoint::new(ProtocolSuite::OpenAiCompatible, "images-generations", "v1");
+        assert_eq!(
+            protocol_log_label(&endpoint),
+            "openai-compatible/images-generations/v1"
+        );
+    }
 }
 
 /// Compute a single upstream URL + method + body triple from the

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -2155,6 +2155,8 @@ async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
         "prompt_cache_key": "codex-session",
         "prompt_cache_retention": "24h",
         "prompt_cache_options": {"mode": "explicit"},
+        "metadata": {"user_id": "codex-session-1"},
+        "include": ["reasoning.encrypted_content"],
         "input": [
             {"role": "user", "content": "weather?"},
             {
@@ -2190,6 +2192,8 @@ async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
     assert!(upstream.get("prompt_cache_key").is_none());
     assert!(upstream.get("prompt_cache_retention").is_none());
     assert!(upstream.get("prompt_cache_options").is_none());
+    assert!(upstream.get("metadata").is_none());
+    assert!(upstream.get("include").is_none());
 }
 
 #[tokio::test]

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -2151,7 +2151,8 @@ async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
     let app = build_deepseek_responses_app(mock_server.uri(), "deepseek-v4-pro");
     let body = json!({
         "model": "deepseek-v4-pro",
-        "reasoning": {"effort": "max", "summary": "none"},
+        "reasoning": {"effort": "max", "summary": "auto"},
+        "text": {"verbosity": "high"},
         "prompt_cache_key": "codex-session",
         "prompt_cache_retention": "24h",
         "prompt_cache_options": {"mode": "explicit"},
@@ -2194,6 +2195,8 @@ async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
     assert!(upstream.get("prompt_cache_options").is_none());
     assert!(upstream.get("metadata").is_none());
     assert!(upstream.get("include").is_none());
+    assert!(upstream["reasoning"].get("summary").is_none());
+    assert!(upstream.get("text").is_none());
 }
 
 #[tokio::test]

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -2031,6 +2031,30 @@ fn build_responses_same_protocol_app(upstream_url: String, model: &str) -> axum:
     }
 }
 
+fn build_deepseek_responses_app(upstream_url: String, virtual_model: &str) -> axum::Router {
+    let mut routing_table = RoutingTable::new();
+    routing_table.insert(
+        virtual_model.to_string(),
+        vec![tiygate_core::RoutingTarget {
+            provider_id: "deepseek".to_string(),
+            model_id: "deepseek-v4-pro".to_string(),
+            api_base: upstream_url,
+            api_key: "sk-deepseek".to_string(),
+            api_protocol: ProtocolEndpoint::new(ProtocolSuite::OpenAiResponses, "responses", "v1"),
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            weight: 1.0,
+            oauth: None,
+        }],
+    );
+    let config_store = ConfigStore::with_routing_table(routing_table);
+    let health = Arc::new(HealthRegistry::with_defaults());
+    let mut config = ServerConfig::default();
+    config.require_api_key = false;
+    ingress::router(config_store, health, &config)
+}
+
 /// Build a same-protocol Gemini app (Gemini ingress → Gemini upstream).
 fn build_gemini_same_protocol_app(upstream_url: String, model: &str) -> axum::Router {
     let mut routing_table = RoutingTable::new();
@@ -2103,6 +2127,88 @@ async fn test_nonstream_responses_same_protocol_passthrough() {
     assert!(serde_json::to_string(&v)
         .unwrap()
         .contains("Same protocol ok"));
+}
+
+#[tokio::test]
+async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
+    let mock_server = wiremock::MockServer::start().await;
+    let upstream_body = json!({
+        "id": "resp_deepseek",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "done"}]
+        }]
+    });
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/responses"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(upstream_body))
+        .mount(&mock_server)
+        .await;
+
+    let app = build_deepseek_responses_app(mock_server.uri(), "deepseek-v4-pro");
+    let body = json!({
+        "model": "deepseek-v4-pro",
+        "reasoning": {"effort": "max", "summary": "none"},
+        "input": [
+            {"role": "user", "content": "weather?"},
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "call weather"}]
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "weather",
+                "arguments": "{}"
+            }
+        ],
+        "tools": [{"type": "function", "name": "weather", "parameters": {"type": "object"}}]
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/responses")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = mock_server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let upstream: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(upstream["reasoning"]["effort"], "max");
+    assert_eq!(upstream["input"][1]["content"][0]["type"], "reasoning_text");
+    assert_eq!(upstream["input"][1]["content"][0]["text"], "call weather");
+    assert!(upstream["input"][1].get("summary").is_none());
+}
+
+#[tokio::test]
+async fn test_deepseek_responses_rejects_unsupported_tool_before_upstream() {
+    let mock_server = wiremock::MockServer::start().await;
+    let app = build_deepseek_responses_app(mock_server.uri(), "deepseek-v4-pro");
+    let body = json!({
+        "model": "deepseek-v4-pro",
+        "input": "search files",
+        "tools": [{"type": "file_search", "vector_store_ids": ["vs_1"]}]
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/responses")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    assert!(String::from_utf8_lossy(&response_body).contains("file_search"));
+    assert!(mock_server.received_requests().await.unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -2152,6 +2152,9 @@ async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
     let body = json!({
         "model": "deepseek-v4-pro",
         "reasoning": {"effort": "max", "summary": "none"},
+        "prompt_cache_key": "codex-session",
+        "prompt_cache_retention": "24h",
+        "prompt_cache_options": {"mode": "explicit"},
         "input": [
             {"role": "user", "content": "weather?"},
             {
@@ -2184,6 +2187,9 @@ async fn test_deepseek_responses_prepares_reasoning_for_native_upstream() {
     assert_eq!(upstream["input"][1]["content"][0]["type"], "reasoning_text");
     assert_eq!(upstream["input"][1]["content"][0]["text"], "call weather");
     assert!(upstream["input"][1].get("summary").is_none());
+    assert!(upstream.get("prompt_cache_key").is_none());
+    assert!(upstream.get("prompt_cache_retention").is_none());
+    assert!(upstream.get("prompt_cache_options").is_none());
 }
 
 #[tokio::test]

--- a/crates/store/src/config_store.rs
+++ b/crates/store/src/config_store.rs
@@ -303,6 +303,11 @@ pub fn snapshot_to_routing_table(snapshot: &ConfigSnapshot) -> RoutingTable {
             };
             let (api_protocol, api_base) =
                 provider_egress_for_target(provider, &t.model_id, &raw_base);
+            // The provider may normalize a route-level base override for the
+            // selected protocol (for example DeepSeek `/v1` Chat versus root
+            // `/responses`). Keep the effective override aligned with that
+            // resolved base instead of restoring the raw pre-normalized URL.
+            let api_base_override = t.api_base_override.as_ref().map(|_| api_base.clone());
             targets.push(RoutingTarget {
                 provider_id: provider.id.clone(),
                 model_id: t.model_id.clone(),
@@ -311,7 +316,7 @@ pub fn snapshot_to_routing_table(snapshot: &ConfigSnapshot) -> RoutingTable {
                 api_protocol,
                 account_label: t.account_label.clone(),
                 api_key_override: t.api_key_override.clone(),
-                api_base_override: t.api_base_override.clone(),
+                api_base_override,
                 weight: t.weight,
                 oauth: oauth_config,
             });

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -83,6 +83,10 @@ verbosity、自动 truncation、禁用并行工具调用、非空 metadata/inclu
 以及 `file_search`、`code_interpreter`、`computer_use`、`mcp` 等工具。允许的工具为
 function、web search，以及名为 `apply_patch` 的 custom tool。
 
+`prompt_cache_key`、`prompt_cache_retention`、`prompt_cache_options` 属于例外：DeepSeek
+自动管理上下文缓存，TiyGate 在 DeepSeek Responses 出站前显式移除这些缓存提示，不将其
+视为影响生成语义的有损转换，也不会因此拒绝 Codex 客户端请求。
+
 来源：[DeepSeek Responses API 指南](https://api-docs.deepseek.com/guides/responses_api/)、
 [DeepSeek Responses API Reference](https://api-docs.deepseek.com/api/create-response/)。
 

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -76,8 +76,10 @@ DeepSeek Provider 仅将 `deepseek-chat` 与 `deepseek-reasoner` 发送到
 `POST /v1/chat/completions`；其余模型统一使用原生 `POST /responses` 出站。DeepSeek
 Responses 的 reasoning item 使用
 `content: [{"type":"reasoning_text","text":"..."}]`，TiyGate 在该 provider profile 下会把
-OpenAI 风格的 `summary` 回放转换为 `reasoning_text`，但拒绝不可转换的
-`encrypted_content`。
+OpenAI 风格的 `summary` 回放转换为 `reasoning_text`。DeepSeek 无法解密 OpenAI 风格加密推理，
+因此当客户端回传带 `encrypted_content` 的 reasoning 项时，TiyGate 会**剥离该加密字段并保留明文
+`summary`/`reasoning_text`**；若该项仅有密文、无任何明文可回放（加密-only shell），则**丢弃整个
+reasoning 项**，而不是拒绝整单请求——与 DeepSeek 对其它“接受但忽略”非语义控制项的处理方式一致。
 
 DeepSeek 会静默忽略部分 OpenAI Responses 能力。为维持 `lossy_default_reject` 契约，
 TiyGate 对有语义影响的不支持项返回 `400 LossyOrCapability`，包括
@@ -93,7 +95,8 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 TiyGate 在 DeepSeek Responses 出站前显式移除这些字段，不将其视为影响生成语义的有损
 转换，也不会因此拒绝 Codex 客户端请求。DeepSeek 不支持加密 reasoning content，
 客户端请求 `include: ["reasoning.encrypted_content"]` 时收到的仍是明文 `reasoning_text`
-——这是 DeepSeek 固有限制，而非剥离所致。
+——这是 DeepSeek 固有限制，而非剥离所致；同理，回传的加密 blob 在出站前被剥离，
+不构成有语义影响的有损转换。
 
 来源：[DeepSeek Responses API 指南](https://api-docs.deepseek.com/guides/responses_api/)、
 [DeepSeek Responses API Reference](https://api-docs.deepseek.com/api/create-response/)。

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -5,7 +5,7 @@
 ## 判定符号
 
 | 符号 | 含义 |
-|------|------|
+| ------ | ------ |
 | ✅ | 无损（双向可逆） |
 | ⚠️ | 有损（`lossy_default_reject` 拒绝） |
 | ❌ | 不支持（目标协议无此能力，拒绝） |
@@ -14,7 +14,7 @@
 ## 1. Tool Calling（工具调用）
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | `function_calling` | ✅ | ✅ | ✅ | ✅ | N/A |
 | `parallel_tool_calls` | ✅ | ⚠️ → chat→msg: 并行工具调用无法在 Anthropic 表达 | ✅ | ⚠️ | N/A |
 | `tool_choice=required` | ✅ | ✅ (via `{type:"any"}`) | ✅ | ✅ (via `toolConfig.functionCallingConfig.mode=ANY`) | N/A |
@@ -22,13 +22,14 @@
 | `tool_result` 引用 | ✅ | ✅ | ✅ | ✅ | N/A |
 
 **有损组合（阶段 1-3 已知）**：
+
 - `chat_completions → messages` 且请求包含 `parallel_tool_calls=true` → **拒绝**
 - `messages → gemini` tool_use 块结构 → **有损**（Gemini 用 `functionCall`/`functionResponse` parts，语义不完全等价）
 
 ## 2. 多模态（Multimodal）
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | `multimodal` | ✅ | ✅ | ✅ | ✅ | N/A |
 | inline base64 | ✅（image） | ✅（image, document） | ✅ | ✅（image, audio, video, pdf） | N/A |
 | URL 引用 | ✅ | ⚠️ → 需要先下载转 inline | ✅ | ✅ | N/A |
@@ -38,6 +39,7 @@
 | `image_url.detail` | ✅ | ❌（lossy：字段丢弃） | ✅ | ❌（lossy：字段丢弃） | N/A |
 
 **有损组合（阶段 1-3 已知）**：
+
 - URL 承载 → `messages`（Anthropic 需要 inline base64，无法传递 URL）→ **拒绝**
 - inline audio → `chat_completions`/`messages` → **拒绝**
 - inline video → 任何非 Gemini → **拒绝**
@@ -47,7 +49,7 @@
 ## 3. Reasoning / 结构化输出
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | `reasoning` | ✅ | ✅ | ✅ | ✅ | N/A |
 | `extended_reasoning` | ❌ | ✅ | ✅ | ✅ | N/A |
 | `structured_output` | ✅ | ✅ | ✅ | ✅ | N/A |
@@ -55,6 +57,7 @@
 | `response_format json_object` | ✅ | ✅¹ | ✅ | ✅ | N/A |
 
 **有损组合（阶段 1-3 已知）**：
+
 - `chat_completions` → 任意 且请求含 `extended_reasoning` → OpenAI 不产生 reasoning，但也不报错，所以 **⚠️ 方向单向有损**
 
 > ¹ Anthropic Messages 以 `output_config.format: {type: "json_schema"}` 表达结构化输出；
@@ -79,13 +82,16 @@ OpenAI 风格的 `summary` 回放转换为 `reasoning_text`，但拒绝不可转
 DeepSeek 会静默忽略部分 OpenAI Responses 能力。为维持 `lossy_default_reject` 契约，
 TiyGate 对有语义影响的不支持项返回 `400 LossyOrCapability`，包括
 `previous_response_id`、conversation/store/background 状态、非 `none` reasoning summary、
-verbosity、自动 truncation、禁用并行工具调用、非空 metadata/include、未支持的 input item，
+verbosity、自动 truncation、禁用并行工具调用、未支持的 input item，
 以及 `file_search`、`code_interpreter`、`computer_use`、`mcp` 等工具。允许的工具为
 function、web search，以及名为 `apply_patch` 的 custom tool。
 
-`prompt_cache_key`、`prompt_cache_retention`、`prompt_cache_options` 属于例外：DeepSeek
-自动管理上下文缓存，TiyGate 在 DeepSeek Responses 出站前显式移除这些缓存提示，不将其
-视为影响生成语义的有损转换，也不会因此拒绝 Codex 客户端请求。
+`prompt_cache_key`、`prompt_cache_retention`、`prompt_cache_options`、`metadata`、`include`
+属于例外：DeepSeek 自动管理上下文缓存并默认返回 reasoning/tool items，且从不解析
+这些非语义控制项，因此 TiyGate 在 DeepSeek Responses 出站前显式移除这些字段，不将其
+视为影响生成语义的有损转换，也不会因此拒绝 Codex 客户端请求。DeepSeek 不支持加密
+reasoning content，客户端请求 `include: ["reasoning.encrypted_content"]` 时收到的仍是
+明文 `reasoning_text`——这是 DeepSeek 固有限制，而非剥离所致。
 
 来源：[DeepSeek Responses API 指南](https://api-docs.deepseek.com/guides/responses_api/)、
 [DeepSeek Responses API Reference](https://api-docs.deepseek.com/api/create-response/)。
@@ -101,7 +107,7 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 ## 5. 诊断用 N×N 跨协议组合矩阵
 
 | Ingress ↓ / Egress → | chat_completions | messages | responses | gemini |
-|----------------------|:---:|:---:|:---:|:---:|
+| ---------------------- | :---: | :---: | :---: | :---: |
 | **chat_completions** | PassThrough ✅ | ⚠️ parallel_tc 可能拒绝 | ✅ | ✅ |
 | **messages** | ✅ | PassThrough ✅ | ✅ | ⚠️ tool_use→functionCall 有损 |
 | **responses** | ⚠️ file_id 丢失 | ⚠️ file_id | PassThrough ✅ | ⚠️ file_id+audio 拒绝 |
@@ -116,7 +122,7 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 ## 6. Thinking / Reasoning 配置
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | `effort` (none/minimal/low/medium/high/xhigh/max) | ✅ (`reasoning_effort`，含 `none`/`max`) | ✅（`none` 表示不下发 thinking；其余使用 `output_config.effort`） | ✅ (`reasoning.effort`，含 `none`/`max`) | ✅（2.5 的 `none` → `thinkingBudget: 0`；3+ 近似为 `minimal`） | N/A |
 | `budget_tokens` | ✅ → 推导 effort（`budget_to_effort`） | ✅ (`thinking.budget_tokens`，enabled 类型) | ✅ → 推导 effort（`budget_to_effort`） | ✅ (Gemini 2.5 `thinkingConfig.thinkingBudget`；3+ → 推导 `thinkingLevel`) | N/A |
 | `display` (summarized/omitted) | ⚠️ → 丢弃 | ✅ (`thinking.display`) | ⚠️ → 丢弃 | ✅ → 推导 `includeThoughts` | N/A |
@@ -127,6 +133,7 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 **跨协议策略**：普通 thinking 配置跨协议时映射或丢弃，不拒绝（thinking 配置不影响语义正确性，只影响模型行为质量）。`mode` / `context` 是 Responses-only 的持久化推理控制；向其他协议转换会以 `LossyDimension::ExtendedReasoning` 明确拒绝，避免静默改变请求行为。
 
 **effort 级别映射**：IR 使用 7 级枚举（None/Minimal/Low/Medium/High/XHigh/Max）。各协议支持级别不同：
+
 - OpenAI Chat/Responses: none/minimal/low/medium/high/xhigh/**max**；server 按真实 upstream model 判定，仅 GPT-5.6 系列保留 max，旧模型降为 xhigh。
 - Anthropic: low/medium/high/xhigh/max；None 不下发 thinking，Minimal → low。
 - Gemini: 3+ 使用 minimal/low/medium/high（None → minimal 近似，XHigh/Max → high）；2.5 使用 `thinkingBudget`，None → 0。官方协议不允许同一请求同时包含 `thinkingLevel` 和 `thinkingBudget`。
@@ -138,7 +145,7 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 ## 6.1 Hosted Tools（Responses 托管工具）
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | function tools | ✅ | ✅ | ✅ | ✅ | N/A |
 | custom tools (`type: "custom"`) | ✅ | ❌ 跨协议拒绝 (`CustomTools`) | ✅ | ❌ 跨协议拒绝 (`CustomTools`) | N/A |
 | hosted tools (`web_search` / `file_search` / `code_interpreter` / `computer_use_preview` 等) | ❌ 跨协议拒绝 | ❌ 跨协议拒绝 | ✅（`Tool.tool_type` + `config` 往返） | ❌ 跨协议拒绝 | N/A |
@@ -149,7 +156,7 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 ## 6.2 Explicit Prompt Caching
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | `prompt_cache_key` | ✅（`openai_extra` 透传） | N/A | ✅（`responses_extra` 透传） | N/A | N/A |
 | `prompt_cache_retention` | ✅（`openai_extra` 透传） | N/A | ✅（`responses_extra` 透传） | N/A | N/A |
 | `prompt_cache_options` | ✅（Chat ↔ Responses 重放） | N/A | ✅（Chat ↔ Responses 重放） | N/A | N/A |
@@ -161,7 +168,7 @@ function、web search，以及名为 `apply_patch` 的 custom tool。
 ## 6.3 GPT-5.6 Text Controls 与 Beta 边界
 
 | 维度 | chat_completions | messages | responses | gemini |
-|------|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: |
 | `verbosity` | ✅ 顶层 `verbosity` | ❌ 跨协议拒绝 | ✅ `text.verbosity` | ❌ 跨协议拒绝 |
 | `safety_identifier` | ✅ | N/A | ✅ | N/A |
 | image `detail: "original"` | ✅ | ⚠️ 无等价语义 | ✅ | ⚠️ 无等价语义 |
@@ -172,7 +179,7 @@ Multi-agent 仍要求客户端显式提供 `OpenAI-Beta: responses_multi_agent=v
 ## 7. Metadata
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | `metadata` KV 对 | ✅ | ⚠️ → 仅保留 `user_id` | ✅ | ✅ (`labels`) | N/A |
 | `user_id` | ✅ | ✅ | ✅ | ✅ | N/A |
 
@@ -181,7 +188,7 @@ Multi-agent 仍要求客户端显式提供 `OpenAI-Beta: responses_multi_agent=v
 ## 8. Annotations / Citations
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | URL citation | ✅ (`annotations[]`) | ⚠️ → 丢弃 | ✅ (`annotations[]`) | ✅ (`groundingMetadata`) | N/A |
 | File citation | ✅ | ⚠️ → 丢弃 | ✅ | ⚠️ → 丢弃 | N/A |
 
@@ -190,7 +197,7 @@ Multi-agent 仍要求客户端显式提供 `OpenAI-Beta: responses_multi_agent=v
 ## 9. Refusal
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | refusal 文本 | ✅ (`message.refusal`) | ⚠️ → 作为 text 输出 | ✅ (`refusal` output item) | ⚠️ → 作为 text 输出 | N/A |
 | refusal stop_reason | ✅ → `content_filter` | ✅ (`stop_reason:"refusal"`) | ✅ → `incomplete` | ✅ → `SAFETY` | N/A |
 
@@ -219,7 +226,7 @@ Codex 客户端在 OpenAI Responses 协议上扩展了若干 item 类型和字�
 ### Codex Input Item 类型
 
 | Item 类型 | 跨协议行为 |
-|-----------|-----------|
+| ----------- | ----------- |
 | `local_shell_call` | ✅ 映射为 IR `Content::ToolCall { name: "local_shell" }`，跨协议可转换 |
 | `local_shell_call_output` | ✅ 映射为 IR `Content::ToolResult`，跨协议可转换 |
 | `custom_tool_call` | ✅ 映射为 IR `Content::ToolCall`（`wire_type=custom_tool_call`，input 文本包装为 JSON arguments）；同协议 re-encode 恢复 `custom_tool_call` |
@@ -236,7 +243,7 @@ Codex 客户端在 OpenAI Responses 协议上扩展了若干 item 类型和字�
 ### Codex Response Output Item 类型
 
 | Item 类型 | 跨协议行为 |
-|-----------|-----------|
+| ----------- | ----------- |
 | `local_shell_call` | ✅ 映射为 IR `Content::ToolCall`，计入 `FinishReason::ToolCalls` 判断 |
 | `custom_tool_call` | ✅ 映射为 IR `Content::ToolCall` |
 | `tool_search_call` / `agent_message` / `compaction` 等 | ⚠️ 静默丢弃（响应中的这些 item 对跨协议客户端无意义） |
@@ -244,7 +251,7 @@ Codex 客户端在 OpenAI Responses 协议上扩展了若干 item 类型和字�
 ### Codex 扩展字段
 
 | 字段 | 跨协议行为 |
-|------|-----------|
+| ------ | ----------- |
 | `reasoning.summary` | ✅ 解析到 IR `ThinkingConfig.summary`，Responses egress 时回写；跨协议到 Anthropic/Gemini 时丢弃（不拒绝） |
 | `text.verbosity` | ✅ 解析到 IR `params.verbosity`；Responses 同协议还通过 `extensions["text"]` 保留完整 `text` 对象；跨协议到非 OpenAI egress 时由 `LossyDimension::Verbosity` **拒绝**（不是静默丢弃） |
 | `client_metadata` | ✅ 加入 `responses_extra` 透传列表，同协议 egress 自动回写；跨协议时丢弃 |
@@ -252,7 +259,7 @@ Codex 客户端在 OpenAI Responses 协议上扩展了若干 item 类型和字�
 ### Codex 自定义请求头
 
 | 头 | 跨协议行为 |
-|----|-----------|
+| ---- | ----------- |
 | `x-codex-*` | ✅ 不在 `DEFAULT_REQUEST_DENY` / `DEFAULT_RESPONSE_DENY` 中，C→G→P 和 P→G→C 方向均自动转发 |
 | `x-openai-subagent` | ✅ 同上 |
 | `x-codex-turn-state` | ✅ 响应头，不在 `DEFAULT_RESPONSE_DENY` 中，自动转发回客户端 |
@@ -263,12 +270,13 @@ Codex 客户端在 OpenAI Responses 协议上扩展了若干 item 类型和字�
 OpenAI Responses Multi-agent Beta（`OpenAI-Beta: responses_multi_agent=v1`）仅在 **Responses 同协议**路径上支持透传；跨协议一律拒绝，不做 IR 类型化或转换。
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |
-|------|:---:|:---:|:---:|:---:|:---:|
+| ------ | :---: | :---: | :---: | :---: | :---: |
 | 顶层 `multi_agent` | ❌ 拒绝 | ❌ 拒绝 | ✅ 同协议透传 / re-encode 保活 | ❌ 拒绝 | N/A |
 | `multi_agent_call` / `multi_agent_call_output` input items | ❌ 拒绝 | ❌ 拒绝 | ✅ 存入有序 `responses_opaque_input_items` + 内容袋 `multi_agent_items`，同协议按原顺序回放 | ❌ 拒绝 | N/A |
 | 跨协议 Convert | ❌ | ❌ | N/A（同协议） | ❌ | N/A |
 
 **运行时行为**：
+
 - 同协议（Responses→Responses）：raw passthrough 与 IR re-encode 均保留 `multi_agent` 与 multi-agent input items；re-encode 通过 `responses_opaque_input_items` 的原始 index 保持与 user/assistant 消息的交错顺序；`OpenAI-Beta` 头按现有 denylist 策略转发。
 - 跨协议：`check_lossy_conversion` 检测到 `responses_extra.multi_agent` 或非空 `multi_agent_items` 时，以 `LossyDimension::MultiAgent` **拒绝**（HTTP 400），不静默丢弃。
 - 不支持 WebSocket multi-agent 长连接；本网关 Responses 面仅为 HTTP + SSE。

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -69,9 +69,9 @@
 
 ### 3.1 DeepSeek Responses profile
 
-DeepSeek 官方 API 的 `deepseek-v4-flash`、`deepseek-v4-pro`、
-`deepseek-v4-flash-vision-exp` 使用原生 `POST /responses` 出站；旧版或未知模型继续使用
-`POST /v1/chat/completions`。DeepSeek Responses 的 reasoning item 使用
+DeepSeek Provider 仅将 `deepseek-chat` 与 `deepseek-reasoner` 发送到
+`POST /v1/chat/completions`；其余模型统一使用原生 `POST /responses` 出站。DeepSeek
+Responses 的 reasoning item 使用
 `content: [{"type":"reasoning_text","text":"..."}]`，TiyGate 在该 provider profile 下会把
 OpenAI 风格的 `summary` 回放转换为 `reasoning_text`，但拒绝不可转换的
 `encrypted_content`。

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -81,17 +81,19 @@ OpenAI 风格的 `summary` 回放转换为 `reasoning_text`，但拒绝不可转
 
 DeepSeek 会静默忽略部分 OpenAI Responses 能力。为维持 `lossy_default_reject` 契约，
 TiyGate 对有语义影响的不支持项返回 `400 LossyOrCapability`，包括
-`previous_response_id`、conversation/store/background 状态、非 `none` reasoning summary、
-verbosity、自动 truncation、禁用并行工具调用、未支持的 input item，
+`previous_response_id`、conversation/store/background 状态、自动 truncation、禁用并行工具
+调用、未支持的 input item，
 以及 `file_search`、`code_interpreter`、`computer_use`、`mcp` 等工具。允许的工具为
 function、web search，以及名为 `apply_patch` 的 custom tool。
 
-`prompt_cache_key`、`prompt_cache_retention`、`prompt_cache_options`、`metadata`、`include`
+`prompt_cache_key`、`prompt_cache_retention`、`prompt_cache_options`、`metadata`、`include`、
+`text.verbosity`、`reasoning.summary`
 属于例外：DeepSeek 自动管理上下文缓存并默认返回 reasoning/tool items，且从不解析
-这些非语义控制项，因此 TiyGate 在 DeepSeek Responses 出站前显式移除这些字段，不将其
-视为影响生成语义的有损转换，也不会因此拒绝 Codex 客户端请求。DeepSeek 不支持加密
-reasoning content，客户端请求 `include: ["reasoning.encrypted_content"]` 时收到的仍是
-明文 `reasoning_text`——这是 DeepSeek 固有限制，而非剥离所致。
+这些非语义控制项（`text.verbosity` 与 `reasoning.summary` 是“接受但忽略”），因此
+TiyGate 在 DeepSeek Responses 出站前显式移除这些字段，不将其视为影响生成语义的有损
+转换，也不会因此拒绝 Codex 客户端请求。DeepSeek 不支持加密 reasoning content，
+客户端请求 `include: ["reasoning.encrypted_content"]` 时收到的仍是明文 `reasoning_text`
+——这是 DeepSeek 固有限制，而非剥离所致。
 
 来源：[DeepSeek Responses API 指南](https://api-docs.deepseek.com/guides/responses_api/)、
 [DeepSeek Responses API Reference](https://api-docs.deepseek.com/api/create-response/)。

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -67,6 +67,25 @@
 > 原始 response contract；拒绝错误携带 JSON Pointer。完整来源和 profile 基线见
 > `protocol-specs/structured-output/anthropic.toml`。
 
+### 3.1 DeepSeek Responses profile
+
+DeepSeek 官方 API 的 `deepseek-v4-flash`、`deepseek-v4-pro`、
+`deepseek-v4-flash-vision-exp` 使用原生 `POST /responses` 出站；旧版或未知模型继续使用
+`POST /v1/chat/completions`。DeepSeek Responses 的 reasoning item 使用
+`content: [{"type":"reasoning_text","text":"..."}]`，TiyGate 在该 provider profile 下会把
+OpenAI 风格的 `summary` 回放转换为 `reasoning_text`，但拒绝不可转换的
+`encrypted_content`。
+
+DeepSeek 会静默忽略部分 OpenAI Responses 能力。为维持 `lossy_default_reject` 契约，
+TiyGate 对有语义影响的不支持项返回 `400 LossyOrCapability`，包括
+`previous_response_id`、conversation/store/background 状态、非 `none` reasoning summary、
+verbosity、自动 truncation、禁用并行工具调用、非空 metadata/include、未支持的 input item，
+以及 `file_search`、`code_interpreter`、`computer_use`、`mcp` 等工具。允许的工具为
+function、web search，以及名为 `apply_patch` 的 custom tool。
+
+来源：[DeepSeek Responses API 指南](https://api-docs.deepseek.com/guides/responses_api/)、
+[DeepSeek Responses API Reference](https://api-docs.deepseek.com/api/create-response/)。
+
 ## 4. 确定性/种子
 
 | 维度 | chat_completions | messages | responses | gemini | embeddings |

--- a/webui/src/pages/RequestLogs.tsx
+++ b/webui/src/pages/RequestLogs.tsx
@@ -1579,8 +1579,14 @@ function protocolCategory(
   p?: string | null,
 ): { label: string; tone: BadgeTone } | null {
   if (!p) return null;
-  // Three-segment form `suite/name/version` → category derived from the name.
+  // Three-segment form `suite/name/version`. Provider-specific endpoints may
+  // use an internal name such as `deepseek-responses`; categorize those by
+  // suite so the log UI still presents the public protocol as Responses.
   const parts = p.split("/");
+  const suite = parts.length >= 2 ? parts[0] : null;
+  if (suite === "openai-responses" || suite === "open_ai_responses") {
+    return { label: "Responses", tone: "success" };
+  }
   const name =
     parts.length >= 3 ? parts[1] : parts.length === 2 ? parts[1] : parts[0];
   switch (name) {

--- a/webui/src/pages/RequestLogs.tsx
+++ b/webui/src/pages/RequestLogs.tsx
@@ -1584,7 +1584,8 @@ function protocolCategory(
   // suite so the log UI still presents the public protocol as Responses.
   const parts = p.split("/");
   const suite = parts.length >= 2 ? parts[0] : null;
-  if (suite === "openai-responses" || suite === "open_ai_responses") {
+  const normalizedSuite = suite?.replace(/[-_]/g, "").toLowerCase();
+  if (normalizedSuite === "openairesponses") {
     return { label: "Responses", tone: "success" };
   }
   const name =
@@ -1593,6 +1594,7 @@ function protocolCategory(
     case "chat-completions":
       return { label: "OpenAI-Compatible", tone: "primary" };
     case "responses":
+    case "deepseek-responses":
       return { label: "Responses", tone: "success" };
     case "messages":
       return { label: "Messages", tone: "warning" };


### PR DESCRIPTION
## Summary
- Route only `deepseek-chat` and `deepseek-reasoner` through Chat Completions; default every other DeepSeek model to the native Responses API
- Normalize protocol-specific API bases and support DeepSeek reasoning_text request, response, and streaming semantics
- Reject unsupported or silently ignored DeepSeek Responses capabilities before contacting the upstream
- Add provider, codec, routing, capability, and WireMock regression coverage and document the compatibility profile

## Test Plan
- [x] `cargo test -p tiygate-protocols -p tiygate-providers -p tiygate-store -p tiygate-server --all-features`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make lint`
- [x] `scripts/verify-deps.sh`
- [x] `cargo test -p tiygate-providers deepseek -- --nocapture`
- [ ] Validate against the live DeepSeek Responses API with production credentials

🤖 Generated with [Codex Cli](https://developers.openai.com/codex/cli/)