### PR TITLE
feat(ingress): ✨ Inject gateway identity headers upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.4] - 2026-09-09
+
 ### :bug: Bug Fixes
+
 - [`6e09907`](https://github.com/tiylabs/tiygate/commit/6e099077fcb59a487a3e843a517af409a16917ac) - **admin**: 🐛 parse nested reset credits accurately *(PR [#64](https://github.com/tiylabs/tiygate/pull/64) by [@jorben](https://github.com/jorben))*
 - [`75027f6`](https://github.com/tiylabs/tiygate/commit/75027f6221d083c761dd710c046d90913508df54) - **stats**: 🐛 Make token dashboard stats atomic *(PR [#66](https://github.com/tiylabs/tiygate/pull/66) by [@jorben](https://github.com/jorben))*
 - [`2b92928`](https://github.com/tiylabs/tiygate/commit/2b92928dec17e1b609ca5166010b04759a85f79f) - **desktop**: 🐛 enforce single instance and unify SQLite URLs *(PR [#68](https://github.com/tiylabs/tiygate/pull/68) by [@jorben](https://github.com/jorben))*
@@ -14,61 +17,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - :arrow_lower_right: *fixes issue [#69](https://github.com/tiylabs/tiygate/issues/69) opened by [@Sereinfy](https://github.com/Sereinfy)*
 - [`61a79a6`](https://github.com/tiylabs/tiygate/commit/61a79a6348fb881fc51e90de2fc7fe126443919e) - **deepseek**: 🐛 Default non-legacy models to Responses *(PR [#71](https://github.com/tiylabs/tiygate/pull/71) by [@jorben](https://github.com/jorben))*
 
-
 ## [0.2.3] - 2026-08-29
+
 ### :sparkles: New Features
+
 - [`d4daad0`](https://github.com/tiylabs/tiygate/commit/d4daad0a47359aee61becfdd5eba6ca1d6e9fe61) - **webui**: ✨ Add page refresh controls *(PR [#62](https://github.com/tiylabs/tiygate/pull/62) by [@jorben](https://github.com/jorben))*
 
-
 ## [0.2.2] - 2026-08-25
+
 ### :sparkles: New Features
+
 - [`1831a1b`](https://github.com/tiylabs/tiygate/commit/1831a1b2345abfe18e02cdc1318e6d50d8625225) - ✨ Add API key virtual model access controls *(PR [#51](https://github.com/tiylabs/tiygate/pull/51) by [@jorben](https://github.com/jorben))*
   - :arrow_lower_right: *addresses issue [#49](https://github.com/tiylabs/tiygate/issues/49) opened by [@2niuhe](https://github.com/2niuhe)*
 
 ### :bug: Bug Fixes
+
 - [`04d019c`](https://github.com/tiylabs/tiygate/commit/04d019c0544fb264667245a6a49eab680fdd1316) - 🐛 strip unsupported Codex output token parameter *(PR [#47](https://github.com/tiylabs/tiygate/pull/47) by [@jorben](https://github.com/jorben))*
 - [`7752c69`](https://github.com/tiylabs/tiygate/commit/7752c695e4991624ea6fd57d80896f0c68685d6f) - **oauth**: 🐛 force store false for Codex requests *(PR [#50](https://github.com/tiylabs/tiygate/pull/50) by [@jorben](https://github.com/jorben))*
 - [`f4f9c7e`](https://github.com/tiylabs/tiygate/commit/f4f9c7e07b1c2c3925bf9da6b19b17e58f60ffb0) - 🐛 preserve Codex OAuth metadata across provider requests *(PR [#53](https://github.com/tiylabs/tiygate/pull/53) by [@jorben](https://github.com/jorben))*
   - :arrow_lower_right: *fixes issue [#52](https://github.com/tiylabs/tiygate/issues/52) opened by [@2niuhe](https://github.com/2niuhe)*
 
-
 ## [0.2.1] - 2026-08-13
+
 ### :sparkles: New Features
+
 - [`30914b4`](https://github.com/tiylabs/tiygate/commit/30914b42176a1ec01bc737be3374b1deb9921968) - **protocols**: ✨ add comprehensive GPT-5.6 protocol support *(PR [#38](https://github.com/tiylabs/tiygate/pull/38) by [@jorben](https://github.com/jorben))*
 - [`bd12eb9`](https://github.com/tiylabs/tiygate/commit/bd12eb909e6964865ee7014b28c11e800f5525a4) - **auth**: ✨ Add coordinated OAuth token keepalive *(PR [#39](https://github.com/tiylabs/tiygate/pull/39) by [@jorben](https://github.com/jorben))*
 - [`2674082`](https://github.com/tiylabs/tiygate/commit/267408245bafb11b20f2bc1060ecb62eb18ec43f) - **oauth**: ✨ Add provider egress profiles and usage windows *(PR [#40](https://github.com/tiylabs/tiygate/pull/40) by [@jorben](https://github.com/jorben))*
 
 ### :bug: Bug Fixes
+
 - [`18a6426`](https://github.com/tiylabs/tiygate/commit/18a64267b384a416ef2f927d9127994cb58a3a0c) - 🐛 Make non-stream upstream timeout configurable *(PR [#44](https://github.com/tiylabs/tiygate/pull/44) by [@jorben](https://github.com/jorben))*
   - :arrow_lower_right: *fixes issue [#43](https://github.com/tiylabs/tiygate/issues/43) opened by [@ddmonster](https://github.com/ddmonster)*
 
-
 ## [0.2.0] - 2026-07-08
+
 ### :sparkles: New Features
+
 - [`ff89669`](https://github.com/tiylabs/tiygate/commit/ff89669d544eab545a019901d85d196f8268f15a) - **store**: ✨ Add per-request cost breakdown and route model-metadata auto-resolution *(PR [#32](https://github.com/tiylabs/tiygate/pull/32) by [@jorben](https://github.com/jorben))*
 - [`29fd594`](https://github.com/tiylabs/tiygate/commit/29fd594a18377fbc374c92dbe62939b3d57a582d) - **ui**: ✨ remove OAuth navigation item from sidebar *(PR [#33](https://github.com/tiylabs/tiygate/pull/33) by [@HayWolf](https://github.com/HayWolf))*
 
 ### :bug: Bug Fixes
+
 - [`b394942`](https://github.com/tiylabs/tiygate/commit/b3949421b6dd30cd3407315d0ab8aa3964a8b2c9) - **webui**: 🐛 keep JSON editor mounted and mark disabled routes *(PR [#36](https://github.com/tiylabs/tiygate/pull/36) by [@jorben](https://github.com/jorben))*
 
 ### :recycle: Refactors
+
 - [`c2c0c96`](https://github.com/tiylabs/tiygate/commit/c2c0c96ad9c22927ad78909c50633b47b612ffb1) - **ui**: ♻️ reorganize request log detail view into tabbed interface *(PR [#34](https://github.com/tiylabs/tiygate/pull/34) by [@HayWolf](https://github.com/HayWolf))*
 
-
 ## [0.1.9] - 2026-07-03
+
 ### :sparkles: New Features
+
 - [`454ac5f`](https://github.com/tiylabs/tiygate/commit/454ac5fdbae900a3891c7faeeac504d4d26719e8) - **admin,webui**: ✨ add route target model auto-discovery with searchable dropdown *(PR [#28](https://github.com/tiylabs/tiygate/pull/28) by [@jorben](https://github.com/jorben))*
 - [`a60cc7e`](https://github.com/tiylabs/tiygate/commit/a60cc7e7d5dc66ccc39a147a43813b5177ab0f56) - **routes**: ✨ add virtual model metadata *(PR [#30](https://github.com/tiylabs/tiygate/pull/30) by [@HayWolf](https://github.com/HayWolf))*
 
 ### :bug: Bug Fixes
+
 - [`ac44de1`](https://github.com/tiylabs/tiygate/commit/ac44de15615381e46b86e8d836e87c1d480a1426) - **store**: 🐛 cast AVG and throughput queries to DOUBLE PRECISION for PostgreSQL *(PR [#24](https://github.com/tiylabs/tiygate/pull/24) by [@HayWolf](https://github.com/HayWolf))*
 - [`1bd9ccd`](https://github.com/tiylabs/tiygate/commit/1bd9ccd737f0135b2cc6020b69166ed4f57fe7fc) - **ingress**: 🐛 disable upstream redirect following to prevent Authorization header stripping *(PR [#27](https://github.com/tiylabs/tiygate/pull/27) by [@jorben](https://github.com/jorben))*
   - :arrow_lower_right: *fixes issue [#26](https://github.com/tiylabs/tiygate/issues/26) opened by [@2niuhe](https://github.com/2niuhe)*
 - [`2981fd7`](https://github.com/tiylabs/tiygate/commit/2981fd735ed49c9dcde165f53e235d3d3dcd455c) - **ui**: 🐛 make Combobox dropdown scrollable inside Radix Dialog *(PR [#29](https://github.com/tiylabs/tiygate/pull/29) by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.8] - 2026-06-30
+
 ### :boom: BREAKING CHANGES
+
 - due to [`d202df8`](https://github.com/tiylabs/tiygate/commit/d202df88fea7adb51a3c6619b4a7fa4d8fc300e6) - ✨ pass structured error code through to client responses *(PR [#18](https://github.com/tiylabs/tiygate/pull/18) by [@HayWolf](https://github.com/HayWolf))*:
 
   error.type field no longer returns "gateway_error";  
@@ -78,70 +92,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
   ---------
 
-
 ### :sparkles: New Features
+
 - [`eed5228`](https://github.com/tiylabs/tiygate/commit/eed5228d4d8846469a21a0d1e53d40f6339d71b2) - **protocols**: ✨ Preserve encrypted reasoning content across multi-turn replay *(PR [#14](https://github.com/tiylabs/tiygate/pull/14) by [@jorben](https://github.com/jorben))*
 - [`e973d71`](https://github.com/tiylabs/tiygate/commit/e973d71cf939f0340e7b72c7440b3c2209399681) - **server**: ✨ add per-hop request attempt logging and fix Anthropic output_config field placement *(PR [#17](https://github.com/tiylabs/tiygate/pull/17) by [@jorben](https://github.com/jorben))*
 - [`d202df8`](https://github.com/tiylabs/tiygate/commit/d202df88fea7adb51a3c6619b4a7fa4d8fc300e6) - **core**: ✨ pass structured error code through to client responses *(PR [#18](https://github.com/tiylabs/tiygate/pull/18) by [@HayWolf](https://github.com/HayWolf))*
 - [`cfc089d`](https://github.com/tiylabs/tiygate/commit/cfc089d95cee6e8be10c7121247107cd0f7396c7) - **models**: ✨ Add models.dev catalog with embedded baseline and runtime refresh *(PR [#20](https://github.com/tiylabs/tiygate/pull/20) by [@jorben](https://github.com/jorben))*
 
 ### :bug: Bug Fixes
+
 - [`f9337e5`](https://github.com/tiylabs/tiygate/commit/f9337e502e22f70aafa674651cb1bc9269be4ef6) - **desktop**: 🐛 Restore missing tray icon *(PR [#16](https://github.com/tiylabs/tiygate/pull/16) by [@jorben](https://github.com/jorben))*
 - [`1286a84`](https://github.com/tiylabs/tiygate/commit/1286a84fc81ebf4f3458e3b5daa591dbeb0f1857) - **streaming**: 🐛 skip end frame when upstream already sent terminal signal *(PR [#19](https://github.com/tiylabs/tiygate/pull/19) by [@jorben](https://github.com/jorben))*
 - [`a3a3e9a`](https://github.com/tiylabs/tiygate/commit/a3a3e9a80afba806e1ef662b1d6c9936078f72bf) - **ingress**: 🐛 add upstream_ttfb_timeout to bound streaming TTFB phase *(PR [#22](https://github.com/tiylabs/tiygate/pull/22) by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.7] - 2026-06-26
+
 ### :sparkles: New Features
+
 - [`db90c48`](https://github.com/tiylabs/tiygate/commit/db90c48fef0e15a8be809165eed8eaffbe169570) - **auth**: ✨ Implement OAuth 2.0 support for Codex/Claude/xAI providers *(PR [#11](https://github.com/tiylabs/tiygate/pull/11) by [@HayWolf](https://github.com/HayWolf))*
 
-
 ## [0.1.6] - 2026-06-24
+
 ### :sparkles: New Features
+
 - [`9704b38`](https://github.com/tiylabs/tiygate/commit/9704b3843d82280f4106b3f16feb52d3c42e03e7) - **store**: ✨ add token stats export/import and fix Tauri desktop download *(PR [#6](https://github.com/tiylabs/tiygate/pull/6) by [@jorben](https://github.com/jorben))*
 
 ### :bug: Bug Fixes
+
 - [`8e56a1c`](https://github.com/tiylabs/tiygate/commit/8e56a1cb00f56ef75a658d8c28179a6bc29cd7ed) - **ingress**: 🐛 inject end frame after stream error and improve admin console UX *(PR [#9](https://github.com/tiylabs/tiygate/pull/9) by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.5] - 2026-06-23
+
 ### :sparkles: New Features
+
 - [`d2accf6`](https://github.com/tiylabs/tiygate/commit/d2accf63c2d1097afe23fd815eb423e5e5ef2ece) - **ui**: ✨ show enabled state in target badges *(commit by [@jorben](https://github.com/jorben))*
 - [`982b5c0`](https://github.com/tiylabs/tiygate/commit/982b5c0eb14aad65d3b00d1d57b9d43266a63a91) - **protocol**: ✨ preserve image_url.detail across protocol translation *(commit by [@jorben](https://github.com/jorben))*
 
 ### :bug: Bug Fixes
+
 - [`0bb6b29`](https://github.com/tiylabs/tiygate/commit/0bb6b29bda1aebce4301b247e7755e3d1c4bbb48) - **ingress**: 🐛 fix passthrough forwarding media-stripped body upstream *(commit by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.4] - 2026-06-22
+
 ### :sparkles: New Features
+
 - [`b4d06e4`](https://github.com/tiylabs/tiygate/commit/b4d06e4b265f0286c92190bcecdd8ddd51739c02) - **ingress**: ✨ detect and log downstream client disconnects during SSE streaming *(commit by [@jorben](https://github.com/jorben))*
 - [`84c3874`](https://github.com/tiylabs/tiygate/commit/84c387418f04721fc597a5d89d6f49839014f375) - **webui**: ✨ add cache hit ratio display and conditionally hide fields in request logs *(commit by [@jorben](https://github.com/jorben))*
 
 ### :recycle: Refactors
+
 - [`58a2912`](https://github.com/tiylabs/tiygate/commit/58a29123143b1e7f5ff9a417705e27d7c64f6164) - **telemetry**: ♻️ normalise request log status and error_class into typed enums *(commit by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.3] - 2026-06-22
+
 ### :sparkles: New Features
+
 - [`aaeb050`](https://github.com/tiylabs/tiygate/commit/aaeb050d1ccfe4f5e2619a7fcbb731fb4c0a6f7e) - **routes**: ✨ enhance target reorder with pointer and keyboard support *(commit by [@jorben](https://github.com/jorben))*
 
 ### :bug: Bug Fixes
+
 - [`212d6f4`](https://github.com/tiylabs/tiygate/commit/212d6f459cdaaf0d7e37b14e5d8c0218bdf5bb8f) - **routes**: ✅ improve target drag-and-drop cancellation and state reset *(commit by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.2] - 2026-06-22
+
 ### :bug: Bug Fixes
+
 - [`8979b0b`](https://github.com/tiylabs/tiygate/commit/8979b0b3a3eec1bb673eacd0e39c4195cbc25442) - **auth**: 🐛 allow remote instances to bypass local first-run setup *(commit by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.1] - 2026-06-21
+
 ### :sparkles: New Features
+
 - [`db91200`](https://github.com/tiylabs/tiygate/commit/db9120082502897fb79e24dc5c0b56530a1aabdd) - **store**: ✨ add SQLite local database maintenance *(commit by [@jorben](https://github.com/jorben))*
 
-
 ## [0.1.0] - 2026-06-20
+
 ### :boom: BREAKING CHANGES
+
 - due to [`9ffb875`](https://github.com/tiylabs/tiygate/commit/9ffb875a921c64485af0b4d45fac4dc0a1361758) - 🐛 correct admin UI routing basename and login redirect *(commit by [@jorben](https://github.com/jorben))*:
 
   Admin console deep links now resolve under `/admin/ui/` with a trailing slash
@@ -167,6 +194,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ---------
 
 ### :sparkles: New Features
+
 - [`0ac7de0`](https://github.com/tiylabs/tiygate/commit/0ac7de0c67686031df9fa1607059919f797839ae) - ✨ Ship complete TiyGate AI gateway — multi-protocol transcoding, admin console, and CI/CD *(commit by [@jorben](https://github.com/jorben))*
 - [`accbd30`](https://github.com/tiylabs/tiygate/commit/accbd30a3bf4722a81f59c1b176d9647a29c4063) - **protocols**: ✨ extend IR with thinking, refusal, metadata, and annotations *(commit by [@jorben](https://github.com/jorben))*
 - [`3c976e1`](https://github.com/tiylabs/tiygate/commit/3c976e14bfdd3eb839a3f2a33239c4415a390da6) - **thinking**: ✨ unify cross-protocol thinking config with 6-level effort enum and bidirectional budget mapping *(commit by [@jorben](https://github.com/jorben))*
@@ -192,6 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`7bb8062`](https://github.com/tiylabs/tiygate/commit/7bb8062d317c2764a826743a41bc1b86fe797d8f) - **ui**: ✨ show instance indicator on login page and enable logout in Tauri *(commit by [@jorben](https://github.com/jorben))*
 
 ### :bug: Bug Fixes
+
 - [`9ffb875`](https://github.com/tiylabs/tiygate/commit/9ffb875a921c64485af0b4d45fac4dc0a1361758) - **webui**: 🐛 correct admin UI routing basename and login redirect *(commit by [@jorben](https://github.com/jorben))*
 - [`8610ef6`](https://github.com/tiylabs/tiygate/commit/8610ef6ba64b30785099cda74f68af2a093993f6) - **protocols**: 🐛 preserve tool call args and usage in OpenAI→Messages streaming *(commit by [@jorben](https://github.com/jorben))*
 - [`9508d6a`](https://github.com/tiylabs/tiygate/commit/9508d6a044de9b2fadba14a0ff72bca678dc14c5) - **oltp**: 🐛 let Anthropic message_delta usage override message_start *(commit by [@jorben](https://github.com/jorben))*
@@ -212,13 +241,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`c196fa2`](https://github.com/tiylabs/tiygate/commit/c196fa228c1f592010643dbc346b5ed018f89011) - **desktop**: 🐛 resolve Windows build and runtime issues *(commit by [@jorben](https://github.com/jorben))*
 
 ### :recycle: Refactors
+
 - [`26d30df`](https://github.com/tiylabs/tiygate/commit/26d30dff8a4b7712577361700cb52e7142d5629b) - **auth**: ♻️ consolidate AuthApplier implementations into crates/auth *(commit by [@jorben](https://github.com/jorben))*
 - [`6a77a51`](https://github.com/tiylabs/tiygate/commit/6a77a5103844b07bfe245d8f6dd9a1a112e73ca8) - **ui**: ♻️ extract useStickyTableScroll hook for sticky table columns *(commit by [@jorben](https://github.com/jorben))*
 
 ### :white_check_mark: Tests
+
 - [`56a891b`](https://github.com/tiylabs/tiygate/commit/56a891bcf6089b59bc7a34c5e72b6881531aa4a8) - **images**: ✅ add snapshot for image generations decode request *(commit by [@jorben](https://github.com/jorben))*
 
 ### :wrench: Chores
+
 - [`2a8d283`](https://github.com/tiylabs/tiygate/commit/2a8d2839339fe300087bc5d09b1ff23e66261c2e) - **ci**: 🔧 add Docker, GitHub Actions workflows and project config *(commit by [@jorben](https://github.com/jorben))*
 - [`bc924f5`](https://github.com/tiylabs/tiygate/commit/bc924f52d52a20fbacedd68b5d66fdf224285393) - 🔧 use env_file for docker-compose service config *(commit by [@jorben](https://github.com/jorben))*
 - [`cca153f`](https://github.com/tiylabs/tiygate/commit/cca153fed6d0b89242d835dd617af65524bc18fb) - **build**: 🔧 make webui dependency installation idempotent *(commit by [@jorben](https://github.com/jorben))*

--- a/crates/server/src/ingress/executors.rs
+++ b/crates/server/src/ingress/executors.rs
@@ -25,10 +25,10 @@ use tiygate_protocols::responses::ResponsesCodec;
 use crate::openai_codex_oauth as codex_oauth;
 
 use super::headers::{
-    extract_rate_limit_headers, extract_retry_after, forward_upstream_resp_headers,
-    forwarded_resp_headers_for_capture, header_map_to_vec, maybe_inject_prompt_cache_key,
-    merge_client_headers, override_model_in_body, prepare_provider_request_body,
-    reqwest_headers_to_vec, spawn_capture,
+    apply_gateway_identity_headers, extract_rate_limit_headers, extract_retry_after,
+    forward_upstream_resp_headers, forwarded_resp_headers_for_capture, header_map_to_vec,
+    maybe_inject_prompt_cache_key, merge_client_headers, override_model_in_body,
+    prepare_provider_request_body, reqwest_headers_to_vec, spawn_capture,
 };
 use super::response_model::ResponseModelOverride;
 use super::streaming::{
@@ -592,6 +592,12 @@ pub(super) async fn execute_upstream(
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     // Capture the egress request (headers + body) for the request-log
     // detail view. We snapshot here, *after* auth injection and just
@@ -1187,6 +1193,12 @@ pub(super) async fn execute_messages_upstream(
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     // Capture egress request (headers + body) for the detail view.
     let mut egress_body_capture = if pass_through_verbatim {
@@ -1769,6 +1781,12 @@ pub(super) async fn execute_embeddings_upstream(
         &state.tunables().header_policy,
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     let egress_body_capture = serde_json::to_string(&upstream_body).ok();
     let req_id_capture = request_id.to_string();
@@ -2019,6 +2037,12 @@ pub(super) async fn execute_responses_upstream(
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     let mut egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
@@ -2854,6 +2878,12 @@ pub(super) async fn execute_gemini_upstream(
     if anthropic_oauth_profile {
         apply_anthropic_oauth_egress_headers(target, &mut upstream_headers, is_stream, request_id)?;
     }
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     let mut egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
@@ -3320,6 +3350,12 @@ pub(super) async fn execute_images_generations_upstream(
         &state.tunables().header_policy,
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     let egress_body_capture = if pass_through_verbatim {
         raw_passthrough_body.map(|s| s.to_string())
@@ -3694,6 +3730,12 @@ pub(super) async fn execute_images_edits_upstream(
         &state.tunables().header_policy,
     );
     apply_provider_auth(target, &mut upstream_headers, &state.oauth_manager).await?;
+    apply_gateway_identity_headers(
+        client_headers,
+        &mut upstream_headers,
+        &state.tunables().header_policy,
+        target.oauth.as_ref(),
+    );
 
     // TODO(prompt-cache): multipart re-encoding is not implemented in
     // v1, so prompt_cache_key cannot be injected for edits requests.

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -25,12 +25,11 @@ pub(super) fn reqwest_headers_to_vec(
 }
 
 /// Merge client request headers into the upstream header map per the
-/// denylist forwarding policy (C→G→P). Called *after* the codec / auth
-/// have populated `upstream_headers` and *before* `apply_provider_auth`
-/// runs, so a forwarded client header never overwrites a header the
-/// gateway already set (codec content-type, etc.) and auth injection
-/// always wins last. Headers blocked by the policy (credentials,
-/// hop-by-hop, gateway-controlled, trace) are skipped.
+/// denylist forwarding policy (C→G→P). Called after the codec has populated
+/// `upstream_headers` and before `apply_provider_auth` runs, so a forwarded
+/// client header never overwrites a header the codec already set (such as
+/// content-type) and auth injection always wins last. Headers blocked by the
+/// policy (credentials, hop-by-hop, gateway-controlled, trace) are skipped.
 pub(super) fn merge_client_headers(
     client: &http::HeaderMap,
     upstream: &mut http::HeaderMap,
@@ -47,6 +46,58 @@ pub(super) fn merge_client_headers(
             continue;
         }
         upstream.insert(name.clone(), value.clone());
+    }
+}
+
+const GATEWAY_IDENTITY_HEADERS: [(&str, &str); 2] = [
+    ("x-title", "TiyGate"),
+    ("http-referer", "https://tiy.ai/gateway"),
+];
+
+/// Resolve TiyGate's upstream identity headers after provider authentication.
+///
+/// Precedence is request denylist → native OAuth client profile → client value
+/// → gateway default. Native profiles only retain values explicitly declared
+/// in their OAuth `extra_headers`; otherwise these headers are omitted so the
+/// gateway does not break the provider's client impersonation contract.
+pub(super) fn apply_gateway_identity_headers(
+    client: &http::HeaderMap,
+    upstream: &mut http::HeaderMap,
+    policy: &tiygate_core::HeaderForwardPolicy,
+    oauth: Option<&tiygate_core::provider::oauth::OAuthTargetConfig>,
+) {
+    let native_oauth = oauth.filter(|config| {
+        !matches!(
+            config.egress_profile,
+            tiygate_core::provider::oauth::OAuthEgressProfile::Standard
+        )
+    });
+
+    for (name, default_value) in GATEWAY_IDENTITY_HEADERS {
+        if !policy.should_forward_request(name) {
+            upstream.remove(name);
+            continue;
+        }
+
+        if let Some(config) = native_oauth {
+            let native_controls_header = config
+                .extra_headers
+                .iter()
+                .any(|(extra_name, _)| extra_name.eq_ignore_ascii_case(name));
+            if !native_controls_header {
+                upstream.remove(name);
+            }
+            continue;
+        }
+
+        if let Some(client_value) = client.get(name) {
+            upstream.insert(http::HeaderName::from_static(name), client_value.clone());
+        } else if !upstream.contains_key(name) {
+            upstream.insert(
+                http::HeaderName::from_static(name),
+                http::HeaderValue::from_static(default_value),
+            );
+        }
     }
 }
 
@@ -621,6 +672,133 @@ pub(super) fn extract_rate_limit_headers(headers: &HeaderMap) -> Vec<(&'static s
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tiygate_core::provider::oauth::{
+        OAuthEgressProfile, OAuthTargetConfig, TokenRequestStyle, UpstreamTransport,
+    };
+
+    fn oauth_config(
+        egress_profile: OAuthEgressProfile,
+        extra_headers: Vec<(String, String)>,
+    ) -> OAuthTargetConfig {
+        OAuthTargetConfig {
+            upstream_transport: UpstreamTransport::Http,
+            egress_profile,
+            token_url: "https://example.com/token".to_string(),
+            client_id: "test-client".to_string(),
+            client_secret: None,
+            refresh_token: "test-refresh-token".to_string(),
+            scopes: Vec::new(),
+            token_request_style: TokenRequestStyle::Form,
+            authorization_header: None,
+            authorization_prefix: None,
+            extra_headers,
+            account_id: None,
+        }
+    }
+
+    #[test]
+    fn gateway_identity_headers_inject_defaults() {
+        let client = http::HeaderMap::new();
+        let mut upstream = http::HeaderMap::new();
+
+        apply_gateway_identity_headers(
+            &client,
+            &mut upstream,
+            &tiygate_core::HeaderForwardPolicy::with_defaults(),
+            None,
+        );
+
+        assert_eq!(upstream["x-title"], "TiyGate");
+        assert_eq!(upstream["http-referer"], "https://tiy.ai/gateway");
+    }
+
+    #[test]
+    fn gateway_identity_headers_preserve_client_values() {
+        let mut client = http::HeaderMap::new();
+        client.insert("x-title", http::HeaderValue::from_static("Client App"));
+        client.insert(
+            "http-referer",
+            http::HeaderValue::from_static("https://client.example"),
+        );
+        let mut upstream = http::HeaderMap::new();
+        upstream.insert("x-title", http::HeaderValue::from_static("Provider App"));
+
+        apply_gateway_identity_headers(
+            &client,
+            &mut upstream,
+            &tiygate_core::HeaderForwardPolicy::with_defaults(),
+            None,
+        );
+
+        assert_eq!(upstream["x-title"], "Client App");
+        assert_eq!(upstream["http-referer"], "https://client.example");
+    }
+
+    #[test]
+    fn gateway_identity_headers_respect_request_denylist() {
+        let mut client = http::HeaderMap::new();
+        client.insert("x-title", http::HeaderValue::from_static("Client App"));
+        client.insert(
+            "http-referer",
+            http::HeaderValue::from_static("https://client.example"),
+        );
+        let mut upstream = client.clone();
+        let policy = tiygate_core::HeaderForwardPolicy::with_defaults()
+            .with_request_deny_extra(["x-title", "http-referer"]);
+
+        apply_gateway_identity_headers(&client, &mut upstream, &policy, None);
+
+        assert!(!upstream.contains_key("x-title"));
+        assert!(!upstream.contains_key("http-referer"));
+    }
+
+    #[test]
+    fn native_oauth_profile_omits_client_and_gateway_values_by_default() {
+        let mut client = http::HeaderMap::new();
+        client.insert("x-title", http::HeaderValue::from_static("Client App"));
+        client.insert(
+            "http-referer",
+            http::HeaderValue::from_static("https://client.example"),
+        );
+        let mut upstream = client.clone();
+        let oauth = oauth_config(OAuthEgressProfile::AnthropicOAuth, Vec::new());
+
+        apply_gateway_identity_headers(
+            &client,
+            &mut upstream,
+            &tiygate_core::HeaderForwardPolicy::with_defaults(),
+            Some(&oauth),
+        );
+
+        assert!(!upstream.contains_key("x-title"));
+        assert!(!upstream.contains_key("http-referer"));
+    }
+
+    #[test]
+    fn native_oauth_profile_honors_explicit_headers() {
+        let mut client = http::HeaderMap::new();
+        client.insert("x-title", http::HeaderValue::from_static("Client App"));
+        client.insert(
+            "http-referer",
+            http::HeaderValue::from_static("https://client.example"),
+        );
+        let mut upstream = client.clone();
+        upstream.insert("x-title", http::HeaderValue::from_static("Codex Desktop"));
+        let oauth = oauth_config(
+            OAuthEgressProfile::OpenAiCodex,
+            vec![("x-title".to_string(), "Codex Desktop".to_string())],
+        );
+
+        apply_gateway_identity_headers(
+            &client,
+            &mut upstream,
+            &tiygate_core::HeaderForwardPolicy::with_defaults(),
+            Some(&oauth),
+        );
+
+        assert_eq!(upstream["x-title"], "Codex Desktop");
+        assert!(!upstream.contains_key("http-referer"));
+    }
 
     #[test]
     fn reasoning_max_is_target_model_aware() {

--- a/crates/server/src/ingress/headers.rs
+++ b/crates/server/src/ingress/headers.rs
@@ -1096,10 +1096,7 @@ mod tests {
         let mut headers = http::HeaderMap::new();
         inject_provider_extra_headers(&provider, "my-key", &mut headers);
 
-        assert_eq!(
-            headers.get("x-test-header").unwrap().to_str().unwrap(),
-            "session-my-key"
-        );
+        assert_eq!(headers["x-test-header"], "session-my-key");
     }
 
     #[test]
@@ -1165,10 +1162,7 @@ mod tests {
         inject_provider_extra_headers(&provider, "my-key", &mut headers);
 
         // Client value should be preserved, not overwritten
-        assert_eq!(
-            headers.get("x-opencode-session").unwrap().to_str().unwrap(),
-            "client-existing-session"
-        );
+        assert_eq!(headers["x-opencode-session"], "client-existing-session");
     }
 
     #[test]
@@ -1200,19 +1194,16 @@ mod tests {
         // Empty key → uses "tiygate-anonymous" sentinel
         let mut headers = http::HeaderMap::new();
         inject_provider_extra_headers(&provider, "", &mut headers);
-        let val = headers.get("x-opencode-session").unwrap().to_str().unwrap();
-        assert_eq!(val, "session-tiygate-anonymous");
+        assert_eq!(headers["x-opencode-session"], "session-tiygate-anonymous");
 
         // "anonymous" key → same sentinel
         let mut headers = http::HeaderMap::new();
         inject_provider_extra_headers(&provider, "anonymous", &mut headers);
-        let val = headers.get("x-opencode-session").unwrap().to_str().unwrap();
-        assert_eq!(val, "session-tiygate-anonymous");
+        assert_eq!(headers["x-opencode-session"], "session-tiygate-anonymous");
 
         // Real key → uses the actual key
         let mut headers = http::HeaderMap::new();
         inject_provider_extra_headers(&provider, "real-key-123", &mut headers);
-        let val = headers.get("x-opencode-session").unwrap().to_str().unwrap();
-        assert_eq!(val, "session-real-key-123");
+        assert_eq!(headers["x-opencode-session"], "session-real-key-123");
     }
 }

--- a/crates/server/tests/wiremock_providers.rs
+++ b/crates/server/tests/wiremock_providers.rs
@@ -203,6 +203,11 @@ async fn test_happy_path_openai_chat_completion() {
             "authorization",
             "Bearer sk-test",
         ))
+        .and(wiremock::matchers::header("x-title", "TiyGate"))
+        .and(wiremock::matchers::header(
+            "http-referer",
+            "https://tiy.ai/gateway",
+        ))
         .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
             "id": "chatcmpl-test",
             "object": "chat.completion",

--- a/docs/request-logging.md
+++ b/docs/request-logging.md
@@ -7,7 +7,7 @@ header 可见、且仅对敏感值脱敏。
 ## 四段链路
 
 | 段 | 含义 | header 字段 | body 字段 | 数据来源 |
-|----|------|-------------|-----------|----------|
+| ---- | ------ | ------------- | ----------- | ---------- |
 | c→g | 客户端 → 网关（ingress 请求） | `redacted_headers_json` | `raw_envelope_json` | `RawEnvelope`（`request_logs`） |
 | g→p | 网关 → 供应商（egress 请求） | `egress_headers_json` | `egress_body` | `ExchangeCapture`（`request_payloads`） |
 | p→g | 供应商 → 网关（upstream 响应） | `upstream_resp_headers_json` | `upstream_resp_body` | `ExchangeCapture` |
@@ -116,10 +116,11 @@ responses、gemini）的 stream 与 non-stream 分支共 9 个发送点，统一
 
 ### 请求方向（C→G→P）
 
-`merge_client_headers()`（`crates/server/src/ingress.rs`）在
+`merge_client_headers()`（`crates/server/src/ingress/headers.rs`）在
 `upstream_headers` 初始化之后、`apply_provider_auth()` 之前，把客户端请求
 header 按 `should_forward_request` 合并进上游请求；已被 codec 设置的 header
-不被覆盖，auth 注入始终最后胜出。默认**不转发**的请求 header：
+不被覆盖，auth 注入始终最后胜出（下述网关身份 header 除外）。默认**不转发**
+的请求 header：
 
 - 凭证类（客户端对网关的凭证，绝不能泄露给 Provider，且网关注入自己的）：
   `authorization`、`proxy-authorization`、`x-api-key`、`anthropic-version`、
@@ -132,6 +133,17 @@ header 按 `should_forward_request` 合并进上游请求；已被 codec 设置�
 
 其余 header（如 `x-debug-id`、`x-correlation-id`）默认转发给 Provider，并如实
 出现在 g→p 段记录中。
+
+所有常规 G→P HTTP 数据面请求还会携带网关身份 header：
+
+- `x-title: TiyGate`
+- `http-referer: https://tiy.ai/gateway`
+
+这两个 header 的优先级为：请求方向黑名单 > 模拟原生 Client 的 OAuth egress
+profile > 客户端 C→G 携带值 > 网关默认值。客户端已经携带时原值转发，不被默认值
+覆盖；`openai_codex`、`anthropic_oauth` 等非 `standard` profile 默认不发送它们，
+但可通过该 OAuth 配置的 `extra_headers` 声明原生 Client 所需的值。黑名单始终拥有
+最高优先级，即使 Provider/OAuth 配置写入同名 header，最终也会移除。
 
 ### 响应方向（P→G→C）
 
@@ -157,8 +169,10 @@ stream 与 non-stream 均生效，且 `client_resp_headers` 记录与实际下�
 在硬编码默认黑名单之上，可通过环境变量追加额外要拦截的 header（逗号分隔，
 大小写不敏感）：
 
-- `TIYGATE_FORWARD_REQUEST_HEADER_DENY` —— 追加请求方向黑名单
-- `TIYGATE_FORWARD_RESPONSE_HEADER_DENY` —— 追加响应方向黑名单
+- `TIYGATE_FORWARD_REQUEST_HEADER_DENY`（运行时设置键：
+  `gateway.forward.request_header_deny`）——追加请求方向黑名单
+- `TIYGATE_FORWARD_RESPONSE_HEADER_DENY`（运行时设置键：
+  `gateway.forward.response_header_deny`）——追加响应方向黑名单
 
 例如 `TIYGATE_FORWARD_REQUEST_HEADER_DENY=x-stainless-lang,x-internal` 会在
 默认基础上额外屏蔽这两个客户端 header。


### PR DESCRIPTION
## Summary
- Add `x-title: TiyGate` and `http-referer: https://tiy.ai/gateway` to every normal G→P HTTP data-plane request (chat completions, messages, responses, Gemini, embeddings, image generations/edits)
- Enforce precedence: request deny-list > native OAuth egress profile > client-supplied value > gateway default
- Suppress both headers when the operator's request deny-list excludes them, and omit them by default for native-client OAuth profiles (`openai_codex`, `anthropic_oauth`) unless their `extra_headers` declares the header
- Document the behavior and the backing runtime settings keys

## Test Plan
- [x] `cargo test -p tiygate-server --lib gateway_identity_headers` (3 passed)
- [x] `cargo test -p tiygate-server --lib native_oauth_profile` (2 passed)
- [x] `cargo test -p tiygate-server --test wiremock_providers test_happy_path_openai_chat_completion` (asserts the headers on the wire)
- [x] `cargo check -p tiygate-server --lib`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p tiygate-server --all-targets --all-features -- -D warnings`

🤖 Generated with [Pi](https://pi.dev/)
